### PR TITLE
Removed "robust_" prefix from switch script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,7 @@ RUN wstool init -j8 ${ROS_WSPACE}/src ${ROS_WSPACE}/deps.rosinstall
 RUN echo "#!/bin/bash\n\
 pushd '${ROS_WSPACE}/src/repo-under-test' && \n\
 git clean -dfx && \n\
-git checkout \"robust_\$1\" && \n\
+git checkout \"\$1\" && \n\
 echo \"switched mode to: \$1\"" > switch \
  && echo "#!/bin/bash\n'${ROS_WSPACE}/switch' robust_fixed_released" > fix \
  && echo "#!/bin/bash\n'${ROS_WSPACE}/switch' robust_buggy_released" > unfix \


### PR DESCRIPTION
The `fix/unfix` script already have the `robust_` prefix. I decided to fix it in the `switch` script so that is clear in the `fix/unfix` script which tag it is calling.

```shell
$ ./fix
/ros_ws/src/repo-under-test /ros_ws
error: pathspec 'robust_robust_fixed_released' did not match any file(s) known to git.
$ ./unfix
/ros_ws/src/repo-under-test /ros_ws
error: pathspec 'robust_robust_buggy_released' did not match any file(s) known to git.

```

```
$ cat fix
#!/bin/bash
'/ros_ws/switch' robust_fixed_released
```
