### PR TITLE
Updated Dockerfile and BugZoo files to use one-fork-many-branch model (fixes #30)

### DIFF
--- a/care-o-bot/care-o-bot.bugzoo.yml
+++ b/care-o-bot/care-o-bot.bugzoo.yml
@@ -11,7 +11,7 @@ blueprints:
       UBUNTU_VERSION: trusty
       ROS_DISTRO: indigo
       CATKIN_PKG: cob_robots
-      REPO_FORK_URL: https://github.com/robust-rosin/b826eae_cob_robots
+      REPO_FORK_URL: https://github.com/robust-rosin/cob_robots
       REPO_BUG_COMMIT: 6ca6d5029d60f1babbb1f66f759837117b68511b
       REPO_FIX_COMMIT: 6ca6d5029d60f1babbb1f66f759837117b68511b
 

--- a/care-o-bot/care-o-bot.bugzoo.yml
+++ b/care-o-bot/care-o-bot.bugzoo.yml
@@ -8,10 +8,12 @@ blueprints:
     arguments:
       IS_BUILD_FAILURE: "no"
       USE_APT_OLD_RELEASES: "no"
-      UBUNTU_VERSION: "trusty"
-      ROS_DISTRO: "indigo"
-      CATKIN_PKG: "cob_robots"
-      REPO_FORK_URL: "https://github.com/robust-rosin/b826eae_cob_robots"
+      UBUNTU_VERSION: trusty
+      ROS_DISTRO: indigo
+      CATKIN_PKG: cob_robots
+      REPO_FORK_URL: https://github.com/robust-rosin/b826eae_cob_robots
+      REPO_BUG_COMMIT: 6ca6d5029d60f1babbb1f66f759837117b68511b
+      REPO_FIX_COMMIT: 6ca6d5029d60f1babbb1f66f759837117b68511b
 
 bugs:
   - name: robust:b826eae

--- a/geometry2/geometry2.bugzoo.yml
+++ b/geometry2/geometry2.bugzoo.yml
@@ -11,7 +11,7 @@ blueprints:
       UBUNTU_VERSION: "14.04.5"
       ROS_DISTRO: indigo
       CATKIN_PKG: tf2_ros
-      REPO_FORK_URL: https://github.com/robust-rosin/b4dc23c_geometry2
+      REPO_FORK_URL: https://github.com/robust-rosin/geometry2
       REPO_BUG_COMMIT: 2b21a3e00a3f96fcd9f194baf6fa160e38fb6c56
       REPO_FIX_COMMIT: 4e442e278e751c4563b83cd5b2e01556ba3e6e45
 
@@ -25,7 +25,7 @@ blueprints:
       UBUNTU_VERSION: 14.04.5
       ROS_DISTRO: indigo
       CATKIN_PKG: tf2_ros
-      REPO_FORK_URL: https://github.com/robust-rosin/b4dc23c_geometry2
+      REPO_FORK_URL: https://github.com/robust-rosin/geometry2
       # FIXME branches need to be created.
       REPO_BUG_COMMIT: a9dbba2e265458ab26a9c2ced03f604c51b95312
       REPO_FIX_COMMIT: b4dc23c54ba06a846c64215a2d8f944c5a1bd036

--- a/geometry2/geometry2.bugzoo.yml
+++ b/geometry2/geometry2.bugzoo.yml
@@ -9,21 +9,26 @@ blueprints:
       IS_BUILD_FAILURE: "no"
       USE_APT_OLD_RELEASES: "no"
       UBUNTU_VERSION: "14.04.5"
-      ROS_DISTRO: "indigo"
-      CATKIN_PKG: "tf2_ros"
-      REPO_FORK_URL: "https://github.com/robust-rosin/b4dc23c_geometry2"
+      ROS_DISTRO: indigo
+      CATKIN_PKG: tf2_ros
+      REPO_FORK_URL: https://github.com/robust-rosin/b4dc23c_geometry2
+      REPO_BUG_COMMIT: 2b21a3e00a3f96fcd9f194baf6fa160e38fb6c56
+      REPO_FIX_COMMIT: 4e442e278e751c4563b83cd5b2e01556ba3e6e45
 
   - type: docker
     tag: robustrosin/robust:12605ab
     file: ../Dockerfile
     context: b4dc23c
     arguments:
-      IS_BUILD_FAILURE: "no"
-      USE_APT_OLD_RELEASES: "no"
-      UBUNTU_VERSION: "14.04.5"
-      ROS_DISTRO: "indigo"
-      CATKIN_PKG: "tf2_ros"
-      REPO_FORK_URL: "https://github.com/robust-rosin/b4dc23c_geometry2"
+      IS_BUILD_FAILURE: no
+      USE_APT_OLD_RELEASES: no
+      UBUNTU_VERSION: 14.04.5
+      ROS_DISTRO: indigo
+      CATKIN_PKG: tf2_ros
+      REPO_FORK_URL: https://github.com/robust-rosin/b4dc23c_geometry2
+      # FIXME branches need to be created.
+      REPO_BUG_COMMIT: a9dbba2e265458ab26a9c2ced03f604c51b95312
+      REPO_FIX_COMMIT: b4dc23c54ba06a846c64215a2d8f944c5a1bd036
 
 bugs:
   - name: robust:b4dc23c

--- a/kobuki/kobuki.bugzoo.yml
+++ b/kobuki/kobuki.bugzoo.yml
@@ -8,9 +8,13 @@ blueprints:
     arguments:
       IS_BUILD_FAILURE: "yes"
       USE_APT_OLD_RELEASES: "no"
-      UBUNTU_VERSION: "xenial"
-      ROS_DISTRO: "kinetic"
-      CATKIN_PKG: "kobuki_ftdi"
+      UBUNTU_VERSION: xenial
+      ROS_DISTRO: kinetic
+      CATKIN_PKG: kobuki_ftdi
+      REPO_FORK_URL: https://github.com/robust-rosin/eed104d_kobuki_core
+      # FIXME CT couldn't see any ROBUST tags or branches on this fork
+      REPO_BUG_COMMIT: 61f4b66366a1084a4fa5c621cedf7bca314468f8
+      REPO_FIX_COMMIT: eed104dcdd8862824598838b65a7e2339f8e660a
 
 bugs:
   - name: robust:eed104d

--- a/kobuki/kobuki.bugzoo.yml
+++ b/kobuki/kobuki.bugzoo.yml
@@ -11,7 +11,7 @@ blueprints:
       UBUNTU_VERSION: xenial
       ROS_DISTRO: kinetic
       CATKIN_PKG: kobuki_ftdi
-      REPO_FORK_URL: https://github.com/robust-rosin/eed104d_kobuki_core
+      REPO_FORK_URL: https://github.com/robust-rosin/kobuki_core
       # FIXME CT couldn't see any ROBUST tags or branches on this fork
       REPO_BUG_COMMIT: 61f4b66366a1084a4fa5c621cedf7bca314468f8
       REPO_FIX_COMMIT: eed104dcdd8862824598838b65a7e2339f8e660a

--- a/ros_comm/ros_comm.bugzoo.yml
+++ b/ros_comm/ros_comm.bugzoo.yml
@@ -11,7 +11,7 @@ blueprints:
       UBUNTU_VERSION: xenial
       ROS_DISTRO: kinetic
       CATKIN_PKG: roscpp
-      REPO_FORK_URL: https://github.com/robust-rosin/ca23e58_ros_comm
+      REPO_FORK_URL: https://github.com/robust-rosin/ros_comm
       REPO_BUG_COMMIT: b64b72664f6d64ba0278382de49b1821165a3966
       REPO_FIX_COMMIT: 348cc17ccb3689febe9adaeeb781a3abc9dbb0f6
 

--- a/ros_comm/ros_comm.bugzoo.yml
+++ b/ros_comm/ros_comm.bugzoo.yml
@@ -8,10 +8,12 @@ blueprints:
     arguments:
       IS_BUILD_FAILURE: "no"
       USE_APT_OLD_RELEASES: "no"
-      UBUNTU_VERSION: "xenial"
-      ROS_DISTRO: "kinetic"
-      CATKIN_PKG: "roscpp"
-      REPO_FORK_URL: "https://github.com/robust-rosin/ca23e58_ros_comm"
+      UBUNTU_VERSION: xenial
+      ROS_DISTRO: kinetic
+      CATKIN_PKG: roscpp
+      REPO_FORK_URL: https://github.com/robust-rosin/ca23e58_ros_comm
+      REPO_BUG_COMMIT: b64b72664f6d64ba0278382de49b1821165a3966
+      REPO_FIX_COMMIT: 348cc17ccb3689febe9adaeeb781a3abc9dbb0f6
 
 bugs:
   - name: robust:ca23e58


### PR DESCRIPTION
To be complete, we just need to update the `REPO_FORK_URL` properties in the BugZoo files once we rename our forks.