### PR TITLE
kobuki: update all 'time-reported' fields.

### DIFF
--- a/kobuki/0416c81/0416c81.bug
+++ b/kobuki/0416c81/0416c81.bug
@@ -28,7 +28,7 @@ bug:
   detected-by: developer
   reported-by: contributor
   issue: https://github.com/yujinrobot/kobuki/issues/262
-  time-reported: 2013-05-24 (01:29)
+  time-reported: 2013-05-24T00:29:17Z
   reproducibility: sometimes
   trace:
 fix:

--- a/kobuki/054c753/054c753.bug
+++ b/kobuki/054c753/054c753.bug
@@ -37,7 +37,7 @@ bug:
   detected-by: developer
   reported-by: contributor
   issue: https://github.com/yujinrobot/kobuki/issues/272
-  time-reported: 2013-06-19 (02:15)
+  time-reported: 2013-06-19T01:15:47Z
   reproducibility: sometimes
   trace:
 fix:

--- a/kobuki/17560e9/17560e9.bug
+++ b/kobuki/17560e9/17560e9.bug
@@ -36,7 +36,7 @@ bug:
   detected-by: compiler
   reported-by: guest user
   issue: https://github.com/yujinrobot/kobuki/issues/348
-  time-reported: 2014-08-22 (21:38)
+  time-reported: 2014-08-22T20:38:36Z
   reproducibility: always
   trace: null
   reproduction: >

--- a/kobuki/27e85fc/27e85fc.bug
+++ b/kobuki/27e85fc/27e85fc.bug
@@ -23,7 +23,7 @@ bug:
   detected-by: compiler
   reported-by: member developer
   issue: https://github.com/yujinrobot/kobuki_desktop/issues/13
-  time-reported: 2013-07-31 (03:30)
+  time-reported: 2013-07-31T02:30:12Z
   reproducibility: always
   trace:
 fix:

--- a/kobuki/2f647af/2f647af.bug
+++ b/kobuki/2f647af/2f647af.bug
@@ -41,7 +41,7 @@ bug:
   detected-by: developer
   reported-by: member developer
   issue: https://github.com/yujinrobot/kobuki/issues/274
-  time-reported: 2013-06-28 (01:26)
+  time-reported: 2013-06-28T00:26:50Z
   reproducibility: always
   trace:
 fix:

--- a/kobuki/4115400/4115400.bug
+++ b/kobuki/4115400/4115400.bug
@@ -25,7 +25,7 @@ bug:
   detected-by: developer
   reported-by: member developer
   issue: https://github.com/yujinrobot/kobuki_desktop/issues/38
-  time-reported: 2014-09-23 (10:51)
+  time-reported: 2014-09-23T09:51:09Z
   reproducibility: always
   trace:
 fix:

--- a/kobuki/45ee84a/45ee84a.bug
+++ b/kobuki/45ee84a/45ee84a.bug
@@ -24,7 +24,7 @@ bug:
   detected-by: developer
   reported-by: member developer
   issue: https://github.com/yujinrobot/kobuki_core/issues/16
-  time-reported: 2015-02-11 (18:21)
+  time-reported: 2015-02-11T18:21:19Z
   reproducibility: always
   trace: ""
   reproduction: >

--- a/kobuki/493e3f9/493e3f9.bug
+++ b/kobuki/493e3f9/493e3f9.bug
@@ -27,7 +27,7 @@ bug:
   detected-by: developer
   reported-by: member developer
   issue: https://github.com/yujinrobot/kobuki/issues/271
-  time-reported: 2013-06-17 (05:24)
+  time-reported: 2013-06-17T04:24:51Z
   reproducibility: always
   trace: null
 fix:

--- a/kobuki/496aac8/496aac8.bug
+++ b/kobuki/496aac8/496aac8.bug
@@ -28,7 +28,7 @@ bug:
   detected-by: developer
   reported-by: member developer
   issue: https://github.com/yujinrobot/kobuki_desktop/issues/18
-  time-reported: 2013-08-26 (07:56)
+  time-reported: 2013-08-26T06:56:30Z
   reproducibility: always
   trace:
 fix:

--- a/kobuki/55e84a6/55e84a6.bug
+++ b/kobuki/55e84a6/55e84a6.bug
@@ -23,7 +23,7 @@ bug:
   detected-by: testing violation
   reported-by: member developer
   issue: https://github.com/yujinrobot/kobuki_desktop/issues/33
-  time-reported: 2014-08-08 (07:25)
+  time-reported: 2014-08-08T06:25:24Z
   reproducibility: always
   trace: |
     PluginManager._load_plugin() could not load plugin "kobuki_qtestsuite/Kobuki Test Suite":

--- a/kobuki/5a44ead/5a44ead.bug
+++ b/kobuki/5a44ead/5a44ead.bug
@@ -26,7 +26,7 @@ bug:
   detected-by: developer
   reported-by: member developer
   issue: https://github.com/yujinrobot/kobuki/issues/270
-  time-reported: 2013-05-31 (06:20)
+  time-reported: 2013-05-31T05:20:00Z
   reproducibility: always
   trace:
 fix:

--- a/kobuki/5abe7d4/5abe7d4.bug
+++ b/kobuki/5abe7d4/5abe7d4.bug
@@ -24,7 +24,7 @@ bug:
   detected-by: compiler
   reported-by: member developer
   issue: https://github.com/yujinrobot/kobuki_desktop/issues/22
-  time-reported: 2013-10-10 (09:51)
+  time-reported: 2013-10-10T08:51:22Z
   reproducibility: always
   trace:
 fix:

--- a/kobuki/5ee65b0/5ee65b0.bug
+++ b/kobuki/5ee65b0/5ee65b0.bug
@@ -38,7 +38,7 @@ bug:
   detected-by: runtime detection
   reported-by: member developer
   issue: https://github.com/yujinrobot/kobuki_desktop/issues/32
-  time-reported: 2014-08-08 (07:03)
+  time-reported: 2014-08-08T06:03:03Z
   reproducibility: always
   trace: null
   reproduction: >

--- a/kobuki/6e748c1/6e748c1.bug
+++ b/kobuki/6e748c1/6e748c1.bug
@@ -41,7 +41,7 @@ bug:
   detected-by: developer
   reported-by: member developer
   issue: https://github.com/yujinrobot/kobuki/issues/324
-  time-reported: 2014-04-21 (07:32)
+  time-reported: 2014-04-21T06:32:43Z
   reproducibility: always
   trace:
 fix:

--- a/kobuki/8a729db/8a729db.bug
+++ b/kobuki/8a729db/8a729db.bug
@@ -40,7 +40,7 @@ bug:
   detected-by: developer
   reported-by: member developer
   issue: https://github.com/yujinrobot/kobuki/issues/350
-  time-reported: 2014-08-26 (06:52)
+  time-reported: 2014-08-26T05:52:55Z
   reproducibility: always
   trace: null
 fix:

--- a/kobuki/8c30446/8c30446.bug
+++ b/kobuki/8c30446/8c30446.bug
@@ -39,7 +39,7 @@ bug:
   detected-by: developer
   reported-by: member developer
   issue: https://github.com/yujinrobot/kobuki/issues/339
-  time-reported: 2014-08-11 (06:11)
+  time-reported: 2014-08-11T05:11:02Z
   reproducibility: always
   trace: null
   reproduction: >

--- a/kobuki/9c8abeb/9c8abeb.bug
+++ b/kobuki/9c8abeb/9c8abeb.bug
@@ -27,7 +27,7 @@ bug:
   detected-by: compiler
   reported-by: guest user
   issue: https://github.com/yujinrobot/kobuki_desktop/issues/25 | https://github.com/yujinrobot/kobuki_desktop/issues/27
-  time-reported: 2014-02-28 (00:52)
+  time-reported: 2014-02-28T00:52:29Z
   reproducibility: always
   trace: ""
   reproduction: >

--- a/kobuki/9de9690/9de9690.bug
+++ b/kobuki/9de9690/9de9690.bug
@@ -32,7 +32,7 @@ bug:
   detected-by: developer
   reported-by: member developer
   issue: https://github.com/yujinrobot/kobuki/issues/305
-  time-reported: 2013-10-09 (10:00)
+  time-reported: 2013-10-09T09:00:42Z
   reproducibility: always
   trace: null
 fix:

--- a/kobuki/a794de9/a794de9.bug
+++ b/kobuki/a794de9/a794de9.bug
@@ -25,7 +25,7 @@ bug:
   detected-by: assertions
   reported-by: guest user
   issue: https://github.com/yujinrobot/kobuki/issues/257
-  time-reported: 2013-05-15 (08:58)
+  time-reported: 2013-05-15T07:58:23Z
   reproducibility: always
   trace:
 fix:

--- a/kobuki/acd5bfb/acd5bfb.bug
+++ b/kobuki/acd5bfb/acd5bfb.bug
@@ -25,7 +25,7 @@ bug:
   detected-by: developer
   reported-by: member developer
   issue: https://github.com/yujinrobot/kobuki_desktop/issues/19
-  time-reported: 2013-08-28 (11:38)
+  time-reported: 2013-08-28T10:38:41Z
   reproducibility: always
   trace:
 fix:

--- a/kobuki/b166c93/b166c93.bug
+++ b/kobuki/b166c93/b166c93.bug
@@ -28,7 +28,7 @@ bug:
   detected-by: user
   reported-by: guest user
   issue: https://github.com/yujinrobot/kobuki_core/issues/22
-  time-reported: 2016-06-17 (01:15)
+  time-reported: 2016-06-17T00:15:54Z
   reproducibility: always
   reproduction-images:
     buggy: 57b89147438e41c46c0a6890ac7082a70c0056c2

--- a/kobuki/b213df3/b213df3.bug
+++ b/kobuki/b213df3/b213df3.bug
@@ -29,7 +29,7 @@ bug:
   detected-by: developer
   reported-by: member developer
   issue: https://github.com/yujinrobot/kobuki/issues/300
-  time-reported: 2013-08-30 (05:41)
+  time-reported: 2013-08-30T04:41:49Z
   reproducibility: always
   trace: null
 fix:

--- a/kobuki/dd40270/dd40270.bug
+++ b/kobuki/dd40270/dd40270.bug
@@ -38,7 +38,7 @@ bug:
   detected-by: runtime detection
   reported-by: member developer
   issue: https://github.com/yujinrobot/kobuki/issues/338
-  time-reported: 2014-08-08 (07:28)
+  time-reported: 2014-08-08T06:28:25Z
   reproducibility: always
   trace: null
   reproduction: >

--- a/kobuki/e3c9bbc/e3c9bbc.bug
+++ b/kobuki/e3c9bbc/e3c9bbc.bug
@@ -30,7 +30,7 @@ bug:
   detected-by: developer
   reported-by: contributor
   issue: https://github.com/yujinrobot/kobuki_desktop/issues/29
-  time-reported: 2014-05-28 (01:47)
+  time-reported: 2014-05-28T00:47:38Z
   reproducibility: always
   trace: null
   reproduction: >

--- a/kobuki/eed104d/eed104d.bug
+++ b/kobuki/eed104d/eed104d.bug
@@ -24,7 +24,7 @@ bug:
   detected-by: build system
   reported-by: guest user
   issue: https://github.com/yujinrobot/kobuki_core/issues/29
-  time-reported: 2017-03-01 (08:57)
+  time-reported: 2017-03-01T08:57:20Z
   reproducibility: always
   trace: |
     CMake Error at /usr/share/cmake-3.2/Modules/FindPkgConfig.cmake:552 (message):

--- a/kobuki/f95c384/f95c384.bug
+++ b/kobuki/f95c384/f95c384.bug
@@ -24,7 +24,7 @@ bug:
   detected-by: build system
   reported-by: contributor
   issue: https://github.com/yujinrobot/kobuki/issues/331
-  time-reported: 2014-07-25 (00:23)
+  time-reported: 2014-07-24T23:23:35Z
   reproducibility: always
   trace: null
 fix:

--- a/kobuki/fd6b589/fd6b589.bug
+++ b/kobuki/fd6b589/fd6b589.bug
@@ -24,7 +24,7 @@ bug:
   detected-by: build system
   reported-by: automatic
   issue: https://github.com/yujinrobot/kobuki_core/issues/2
-  time-reported: 2013-08-31 (03:02)
+  time-reported: 2013-08-31T02:02:52Z
   reproducibility: always
   trace:
 fix:

--- a/kobuki/pre_2013_04_22/0027b57/0027b57.bug
+++ b/kobuki/pre_2013_04_22/0027b57/0027b57.bug
@@ -29,7 +29,7 @@ bug:
   detected-by: compiler
   reported-by: guest user
   issue: https://github.com/yujinrobot/kobuki/issues/220
-  time-reported: 2013-01-24 (21:33)
+  time-reported: 2013-01-24T21:33:53Z
   reproducibility: sometimes
   trace: N/A
 fix:

--- a/kobuki/pre_2013_04_22/03660af/03660af.bug
+++ b/kobuki/pre_2013_04_22/03660af/03660af.bug
@@ -25,7 +25,7 @@ bug:
   detected-by: developer
   reported-by: member developer
   issue: https://github.com/yujinrobot/kobuki/issues/125
-  time-reported: 2012-06-04 (05:54)
+  time-reported: 2012-06-04T04:54:19Z
   reproducibility: rare
   trace:
 fix:

--- a/kobuki/pre_2013_04_22/1c141a5/1c141a5.bug
+++ b/kobuki/pre_2013_04_22/1c141a5/1c141a5.bug
@@ -28,7 +28,7 @@ bug:
   detected-by: developer
   reported-by: contributor
   issue: https://github.com/yujinrobot/kobuki/issues/246
-  time-reported: 2013-04-05 (10:27)
+  time-reported: 2013-04-05T09:27:36Z
   reproducibility: always
   trace:
 fix:

--- a/kobuki/pre_2013_04_22/35682ec/35682ec.bug
+++ b/kobuki/pre_2013_04_22/35682ec/35682ec.bug
@@ -40,7 +40,7 @@ bug:
   detected-by: developer
   reported-by: contributor
   issue: https://github.com/yujinrobot/kobuki/issues/235
-  time-reported: 2013-02-25 (07:37)
+  time-reported: 2013-02-25T07:37:24Z
   reproducibility: always
   trace: null
 fix:

--- a/kobuki/pre_2013_04_22/38bee3a/38bee3a.bug
+++ b/kobuki/pre_2013_04_22/38bee3a/38bee3a.bug
@@ -24,7 +24,7 @@ bug:
   detected-by: developer
   reported-by: contributor
   issue: https://github.com/yujinrobot/kobuki/issues/169
-  time-reported: 2012-11-21 (00:03)
+  time-reported: 2012-11-21T00:03:13Z
   reproducibility: sometimes
   trace:
 fix:

--- a/kobuki/pre_2013_04_22/38dce2a/38dce2a.bug
+++ b/kobuki/pre_2013_04_22/38dce2a/38dce2a.bug
@@ -32,7 +32,7 @@ bug:
   detected-by: developer
   reported-by: member developer
   issue: https://github.com/yujinrobot/kobuki/issues/185
-  time-reported: 2012-12-01 (16:15)
+  time-reported: 2012-12-01T16:15:01Z
   reproducibility: always
   trace:
 fix:

--- a/kobuki/pre_2013_04_22/3c4c399/3c4c399.bug
+++ b/kobuki/pre_2013_04_22/3c4c399/3c4c399.bug
@@ -26,7 +26,7 @@ bug:
   detected-by: developer
   reported-by: member developer
   issue: https://github.com/yujinrobot/kobuki/issues/240
-  time-reported: 2013-02-28 (07:50)
+  time-reported: 2013-02-28T07:50:34Z
   reproducibility: rare
   trace:
 fix:

--- a/kobuki/pre_2013_04_22/3c7f92a/3c7f92a.bug
+++ b/kobuki/pre_2013_04_22/3c7f92a/3c7f92a.bug
@@ -24,7 +24,7 @@ bug:
   detected-by: runtime crash
   reported-by: member developer
   issue: https://github.com/yujinrobot/kobuki_desktop/issues/9
-  time-reported: 2013-03-12 (04:20)
+  time-reported: 2013-03-12T04:20:06Z
   reproducibility: always
   trace: >
     Traceback (most recent call last): File "/opt/ros/groovy/lib/python2.7/dist-packages/rqt_plot/plot_widget.py", line 168, in update_plot self.data_plot.redraw() File "/opt/turtlebot/kobuki_desktop/kobuki_qtestsuite/plugins/../src/kobuki_qtestsuite/full_size_data_plot.py", line 54, in redraw data_x, data_y, plot = curve ValueError: too many values to unpack

--- a/kobuki/pre_2013_04_22/3e88010/3e88010.bug
+++ b/kobuki/pre_2013_04_22/3e88010/3e88010.bug
@@ -24,7 +24,7 @@ bug:
   detected-by: runtime crash
   reported-by: contributor
   issue: https://github.com/yujinrobot/kobuki/issues/234
-  time-reported: 2013-02-25 (04:32)
+  time-reported: 2013-02-25T04:32:32Z
   reproducibility: always
   trace:
 fix:

--- a/kobuki/pre_2013_04_22/4ea5ea7/4ea5ea7.bug
+++ b/kobuki/pre_2013_04_22/4ea5ea7/4ea5ea7.bug
@@ -25,7 +25,7 @@ bug:
   detected-by: runtime crash
   reported-by: member developer
   issue: https://github.com/yujinrobot/kobuki/issues/207
-  time-reported: 2012-12-27 (15:23)
+  time-reported: 2012-12-27T15:23:00Z
   reproducibility: always
   trace:
 fix:

--- a/kobuki/pre_2013_04_22/606b8b9/606b8b9.bug
+++ b/kobuki/pre_2013_04_22/606b8b9/606b8b9.bug
@@ -25,7 +25,7 @@ bug:
   detected-by: runtime crash
   reported-by: contributor
   issue: https://github.com/yujinrobot/kobuki/issues/225
-  time-reported: 2013-02-18 (06:52)
+  time-reported: 2013-02-18T06:52:19Z
   reproducibility: always
   trace:
 fix:

--- a/kobuki/pre_2013_04_22/62a38a9/62a38a9.bug
+++ b/kobuki/pre_2013_04_22/62a38a9/62a38a9.bug
@@ -43,7 +43,7 @@ bug:
   detected-by: runtime crash
   reported-by: member developer
   issue: https://github.com/yujinrobot/kobuki/issues/23
-  time-reported: 2012-04-05 (22:35)
+  time-reported: 2012-04-05T21:35:09Z
   reproducibility: sometimes
   trace: |
     terminate called after throwing an instance of 'ecl::StandardException'

--- a/kobuki/pre_2013_04_22/8163705/8163705.bug
+++ b/kobuki/pre_2013_04_22/8163705/8163705.bug
@@ -25,7 +25,7 @@ bug:
   detected-by: developer
   reported-by: contributor
   issue: https://github.com/yujinrobot/kobuki/issues/178
-  time-reported: 2012-11-27 (15:13)
+  time-reported: 2012-11-27T15:13:11Z
   reproducibility: sometimes
   trace:
 fix:

--- a/kobuki/pre_2013_04_22/841720a/841720a.bug
+++ b/kobuki/pre_2013_04_22/841720a/841720a.bug
@@ -23,7 +23,7 @@ bug:
   detected-by: developer
   reported-by: contributor
   issue: https://github.com/yujinrobot/kobuki/issues/137
-  time-reported: 2012-06-20 (05:35)
+  time-reported: 2012-06-20T04:35:39Z
   reproducibility: always
   trace:
 fix:

--- a/kobuki/pre_2013_04_22/9397c6b/9397c6b.bug
+++ b/kobuki/pre_2013_04_22/9397c6b/9397c6b.bug
@@ -28,7 +28,7 @@ bug:
   detected-by: developer
   reported-by: contributor
   issue: https://github.com/yujinrobot/kobuki/issues/172
-  time-reported: 2012-11-22 (01:47)
+  time-reported: 2012-11-22T01:47:19Z
   reproducibility: sometimes
   trace:
 fix:

--- a/kobuki/pre_2013_04_22/95b24e8/95b24e8.bug
+++ b/kobuki/pre_2013_04_22/95b24e8/95b24e8.bug
@@ -24,7 +24,7 @@ bug:
   detected-by: developer
   reported-by: member developer
   issue: https://github.com/yujinrobot/kobuki/issues/22
-  time-reported: 2012-04-05 (21:41)
+  time-reported: 2012-04-05T20:41:37Z
   reproducibility: always
   trace:
 fix:

--- a/kobuki/pre_2013_04_22/9682b9a/9682b9a.bug
+++ b/kobuki/pre_2013_04_22/9682b9a/9682b9a.bug
@@ -32,7 +32,7 @@ bug:
   detected-by: runtime crash
   reported-by: contributor
   issue: https://github.com/yujinrobot/kobuki_desktop/issues/10
-  time-reported: 2013-04-02 (12:45)
+  time-reported: 2013-04-02T11:45:01Z
   reproducibility: always
   trace: |
     Traceback (most recent call last):

--- a/kobuki/pre_2013_04_22/ad906f0/ad906f0.bug
+++ b/kobuki/pre_2013_04_22/ad906f0/ad906f0.bug
@@ -28,7 +28,7 @@ bug:
   detected-by: developer
   reported-by: contributor
   issue: https://github.com/yujinrobot/kobuki/issues/126 | https://github.com/yujinrobot/kobuki/issues/111
-  time-reported: 2012-06-04 (05:56)
+  time-reported: 2012-06-04T04:56:40Z
   reproducibility: always
   trace:
 fix:

--- a/kobuki/pre_2013_04_22/af7946f/af7946f.bug
+++ b/kobuki/pre_2013_04_22/af7946f/af7946f.bug
@@ -26,7 +26,7 @@ bug:
   detected-by: developer
   reported-by: member developer
   issue: https://github.com/yujinrobot/kobuki/issues/113
-  time-reported: 2012-05-17 (11:24)
+  time-reported: 2012-05-17T10:24:41Z
   reproducibility: sometimes
   trace:
 fix:

--- a/kobuki/pre_2013_04_22/b18f559/b18f559.bug
+++ b/kobuki/pre_2013_04_22/b18f559/b18f559.bug
@@ -26,7 +26,7 @@ bug:
   detected-by: developer
   reported-by: member developer
   issue: https://github.com/yujinrobot/kobuki/issues/27
-  time-reported: 2012-04-09 (06:24)
+  time-reported: 2012-04-09T05:24:47Z
   reproducibility: always
   trace:
 fix:

--- a/kobuki/pre_2013_04_22/b5f0943/b5f0943.bug
+++ b/kobuki/pre_2013_04_22/b5f0943/b5f0943.bug
@@ -31,7 +31,7 @@ bug:
   detected-by: developer
   reported-by: member developer
   issue: https://github.com/yujinrobot/kobuki/issues/166
-  time-reported: 2012-11-15 (09:12)
+  time-reported: 2012-11-15T09:12:47Z
   reproducibility: always
   trace:
 fix:

--- a/kobuki/pre_2013_04_22/bb3c7ec/bb3c7ec.bug
+++ b/kobuki/pre_2013_04_22/bb3c7ec/bb3c7ec.bug
@@ -30,7 +30,7 @@ bug:
   detected-by: developer
   reported-by: contributor
   issue: https://github.com/yujinrobot/kobuki/issues/136
-  time-reported: 2012-06-20 (03:51)
+  time-reported: 2012-06-20T02:51:39Z
   reproducibility: always
   trace:
 fix:

--- a/kobuki/pre_2013_04_22/c04eae5/c04eae5.bug
+++ b/kobuki/pre_2013_04_22/c04eae5/c04eae5.bug
@@ -23,7 +23,7 @@ bug:
   detected-by: developer
   reported-by: member developer
   issue: https://github.com/yujinrobot/kobuki/issues/175
-  time-reported: 2012-11-24 (07:41)
+  time-reported: 2012-11-24T07:41:21Z
   reproducibility: always
   trace:
 fix:

--- a/kobuki/pre_2013_04_22/d9aa656/d9aa656.bug
+++ b/kobuki/pre_2013_04_22/d9aa656/d9aa656.bug
@@ -26,7 +26,7 @@ bug:
   detected-by: user
   reported-by: member developer
   issue: https://github.com/yujinrobot/kobuki/issues/109
-  time-reported: 2012-05-16 (17:10)
+  time-reported: 2012-05-16T16:10:04Z
   reproducibility: sometimes
   trace:
 fix:

--- a/kobuki/pre_2013_04_22/dbcdb12/dbcdb12.bug
+++ b/kobuki/pre_2013_04_22/dbcdb12/dbcdb12.bug
@@ -40,7 +40,7 @@ bug:
   detected-by: developer
   reported-by: member developer
   issue: https://github.com/yujinrobot/kobuki/issues/183
-  time-reported: 2012-12-01 (02:51)
+  time-reported: 2012-12-01T02:51:33Z
   reproducibility: always
   trace:
 fix:

--- a/kobuki/pre_2013_04_22/e34428d/e34428d.bug
+++ b/kobuki/pre_2013_04_22/e34428d/e34428d.bug
@@ -24,7 +24,7 @@ bug:
   detected-by: developer
   reported-by: member developer
   issue: https://github.com/yujinrobot/kobuki/issues/123
-  time-reported: 2012-06-04 (01:55)
+  time-reported: 2012-06-04T00:55:19Z
   reproducibility: always
   trace:
 fix:

--- a/kobuki/pre_2013_04_22/e45b2b6/e45b2b6.bug
+++ b/kobuki/pre_2013_04_22/e45b2b6/e45b2b6.bug
@@ -25,7 +25,7 @@ bug:
   detected-by: developer
   reported-by: member developer
   issue: https://github.com/yujinrobot/kobuki/issues/73
-  time-reported: 2012-04-16 (06:41)
+  time-reported: 2012-04-16T05:41:17Z
   reproducibility: always
   trace:
 fix:

--- a/kobuki/pre_2013_04_22/e964bbb/e964bbb.bug
+++ b/kobuki/pre_2013_04_22/e964bbb/e964bbb.bug
@@ -25,7 +25,7 @@ bug:
   detected-by: developer
   reported-by: contributor
   issue: https://github.com/yujinrobot/kobuki/issues/227
-  time-reported: 2013-02-22 (09:09)
+  time-reported: 2013-02-22T09:09:21Z
   reproducibility: always
   trace:
 fix:

--- a/kobuki/pre_2013_04_22/f548cc7/f548cc7.bug
+++ b/kobuki/pre_2013_04_22/f548cc7/f548cc7.bug
@@ -35,7 +35,7 @@ bug:
   detected-by: runtime crash
   reported-by: contributor
   issue: https://github.com/yujinrobot/kobuki/issues/180
-  time-reported: 2012-11-27 (15:21)
+  time-reported: 2012-11-27T15:21:53Z
   reproducibility: always
   trace: |
     [FATAL] [1354029622.148262110]: ASSERTION FAILED

--- a/kobuki/pre_2013_04_22/fbe70c7/fbe70c7.bug
+++ b/kobuki/pre_2013_04_22/fbe70c7/fbe70c7.bug
@@ -28,7 +28,7 @@ bug:
   detected-by: developer
   reported-by: member developer
   issue: https://github.com/yujinrobot/kobuki/issues/25
-  time-reported: 2012-04-05 (23:58)
+  time-reported: 2012-04-05T22:58:49Z
   reproducibility: always
   trace:
 fix:


### PR DESCRIPTION
As per subject.

For some bugs there was an offset of 2 hrs between the timestamp in the `.bug` and the one returned by Github (using the GH API).

This could be caused by GMT+1 with DST at the time the `.bug` was created/added.
