### PR TITLE
Reproduce 3e32933

### DIFF
--- a/doc/progress.csv
+++ b/doc/progress.csv
@@ -19,3 +19,4 @@ f01d952, turtlebot, Yes, Yes, Yes, No
 891cb68, turtlebot, Yes, Yes, No, Yes
 fd6b589, kobuki, Yes, Yes, No, Yes
 b213df3, kobuki, Yes, Yes, Yes, Yes
+3e32933, turtlebot, Yes, Yes, Yes, No

--- a/doc/progress.csv
+++ b/doc/progress.csv
@@ -19,4 +19,4 @@ f01d952, turtlebot, Yes, Yes, Yes, No
 891cb68, turtlebot, Yes, Yes, No, Yes
 fd6b589, kobuki, Yes, Yes, No, Yes
 b213df3, kobuki, Yes, Yes, Yes, Yes
-3e32933, turtlebot, Yes, Yes, Yes, No
+3e32933, turtlebot, Yes, Yes, Yes, Yes

--- a/turtlebot/3e32933/3e32933.bug
+++ b/turtlebot/3e32933/3e32933.bug
@@ -32,7 +32,17 @@ bug:
   issue: https://github.com/turtlebot/turtlebot/issues/103
   time-reported: 2013-10-16 (04:53)
   reproducibility: sometimes
-  trace:
+  trace: null
+  reproduction-images:
+    buggy: cfcd70fcb30a2c3363303e1666dba9d77fa25578
+    fixed: 742746f34156e1a9285892c201a21da2078fdd84
+    rosdistro: 88c7076c1e6418079b94c653974737b27aa180f6
+    note: >
+        This is an L2 reproduction.
+        The original launch file starts nodes that rely on hardware, but are not
+        relevant to illustrate the bug and the fix themselves.
+        As such, the bug_witness.test in this case contains a slice of the
+        original launch file, and the buggy and fixed versions are different.
 fix:
   repo: https://github.com/turtlebot/turtlebot
   hash: 3e32933c829e308600707a9f971334d13d1cbe19

--- a/turtlebot/3e32933/deps.rosinstall
+++ b/turtlebot/3e32933/deps.rosinstall
@@ -1,0 +1,617 @@
+- tar:
+    local-name: actionlib
+    uri: https://github.com/ros-gbp/actionlib-release/archive/release/hydro/actionlib/1.10.3-0.tar.gz
+    version: actionlib-release-release-hydro-actionlib-1.10.3-0
+- tar:
+    local-name: angles
+    uri: https://github.com/ros-gbp/geometry_angles_utils-release/archive/release/hydro/angles/1.9.9-0.tar.gz
+    version: geometry_angles_utils-release-release-hydro-angles-1.9.9-0
+- tar:
+    local-name: bfl
+    uri: https://github.com/ros-gbp/bfl-release/archive/release/hydro/bfl/0.7.0-3.tar.gz
+    version: bfl-release-release-hydro-bfl-0.7.0-3
+- tar:
+    local-name: bond_core/bond
+    uri: https://github.com/ros-gbp/bond_core-release/archive/release/hydro/bond/1.7.13-0.tar.gz
+    version: bond_core-release-release-hydro-bond-1.7.13-0
+- tar:
+    local-name: bond_core/bondcpp
+    uri: https://github.com/ros-gbp/bond_core-release/archive/release/hydro/bondcpp/1.7.13-0.tar.gz
+    version: bond_core-release-release-hydro-bondcpp-1.7.13-0
+- tar:
+    local-name: bond_core/smclib
+    uri: https://github.com/ros-gbp/bond_core-release/archive/release/hydro/smclib/1.7.13-0.tar.gz
+    version: bond_core-release-release-hydro-smclib-1.7.13-0
+- tar:
+    local-name: catkin
+    uri: https://github.com/ros-gbp/catkin-release/archive/release/hydro/catkin/0.5.86-0.tar.gz
+    version: catkin-release-release-hydro-catkin-0.5.86-0
+- tar:
+    local-name: class_loader
+    uri: https://github.com/ros-gbp/class_loader-release/archive/release/hydro/class_loader/0.2.5-0.tar.gz
+    version: class_loader-release-release-hydro-class_loader-0.2.5-0
+- tar:
+    local-name: cmake_modules
+    uri: https://github.com/ros-gbp/cmake_modules-release/archive/release/hydro/cmake_modules/0.2.1-1.tar.gz
+    version: cmake_modules-release-release-hydro-cmake_modules-0.2.1-1
+- tar:
+    local-name: common_msgs/actionlib_msgs
+    uri: https://github.com/ros-gbp/common_msgs-release/archive/release/hydro/actionlib_msgs/1.10.6-0.tar.gz
+    version: common_msgs-release-release-hydro-actionlib_msgs-1.10.6-0
+- tar:
+    local-name: common_msgs/diagnostic_msgs
+    uri: https://github.com/ros-gbp/common_msgs-release/archive/release/hydro/diagnostic_msgs/1.10.6-0.tar.gz
+    version: common_msgs-release-release-hydro-diagnostic_msgs-1.10.6-0
+- tar:
+    local-name: common_msgs/geometry_msgs
+    uri: https://github.com/ros-gbp/common_msgs-release/archive/release/hydro/geometry_msgs/1.10.6-0.tar.gz
+    version: common_msgs-release-release-hydro-geometry_msgs-1.10.6-0
+- tar:
+    local-name: common_msgs/nav_msgs
+    uri: https://github.com/ros-gbp/common_msgs-release/archive/release/hydro/nav_msgs/1.10.6-0.tar.gz
+    version: common_msgs-release-release-hydro-nav_msgs-1.10.6-0
+- tar:
+    local-name: common_msgs/sensor_msgs
+    uri: https://github.com/ros-gbp/common_msgs-release/archive/release/hydro/sensor_msgs/1.10.6-0.tar.gz
+    version: common_msgs-release-release-hydro-sensor_msgs-1.10.6-0
+- tar:
+    local-name: common_msgs/stereo_msgs
+    uri: https://github.com/ros-gbp/common_msgs-release/archive/release/hydro/stereo_msgs/1.10.6-0.tar.gz
+    version: common_msgs-release-release-hydro-stereo_msgs-1.10.6-0
+- tar:
+    local-name: common_msgs/visualization_msgs
+    uri: https://github.com/ros-gbp/common_msgs-release/archive/release/hydro/visualization_msgs/1.10.6-0.tar.gz
+    version: common_msgs-release-release-hydro-visualization_msgs-1.10.6-0
+- tar:
+    local-name: console_bridge
+    uri: https://github.com/ros-gbp/console_bridge-release/archive/release/hydro/console_bridge/0.2.4-1.tar.gz
+    version: console_bridge-release-release-hydro-console_bridge-0.2.4-1
+- tar:
+    local-name: depthimage_to_laserscan
+    uri: https://github.com/ros-gbp/depthimage_to_laserscan-release/archive/release/hydro/depthimage_to_laserscan/1.0.6-0.tar.gz
+    version: depthimage_to_laserscan-release-release-hydro-depthimage_to_laserscan-1.0.6-0
+- tar:
+    local-name: diagnostics/diagnostic_aggregator
+    uri: https://github.com/ros-gbp/diagnostics-release/archive/release/hydro/diagnostic_aggregator/1.8.0-0.tar.gz
+    version: diagnostics-release-release-hydro-diagnostic_aggregator-1.8.0-0
+- tar:
+    local-name: diagnostics/diagnostic_updater
+    uri: https://github.com/ros-gbp/diagnostics-release/archive/release/hydro/diagnostic_updater/1.8.0-0.tar.gz
+    version: diagnostics-release-release-hydro-diagnostic_updater-1.8.0-0
+- tar:
+    local-name: dynamic_reconfigure
+    uri: https://github.com/ros-gbp/dynamic_reconfigure-release/archive/release/hydro/dynamic_reconfigure/1.5.36-0.tar.gz
+    version: dynamic_reconfigure-release-release-hydro-dynamic_reconfigure-1.5.36-0
+- tar:
+    local-name: ecl_core/ecl_command_line
+    uri: https://github.com/yujinrobot-release/ecl_core-release/archive/release/hydro/ecl_command_line/0.60.8-0.tar.gz
+    version: ecl_core-release-release-hydro-ecl_command_line-0.60.8-0
+- tar:
+    local-name: ecl_core/ecl_concepts
+    uri: https://github.com/yujinrobot-release/ecl_core-release/archive/release/hydro/ecl_concepts/0.60.8-0.tar.gz
+    version: ecl_core-release-release-hydro-ecl_concepts-0.60.8-0
+- tar:
+    local-name: ecl_core/ecl_containers
+    uri: https://github.com/yujinrobot-release/ecl_core-release/archive/release/hydro/ecl_containers/0.60.8-0.tar.gz
+    version: ecl_core-release-release-hydro-ecl_containers-0.60.8-0
+- tar:
+    local-name: ecl_core/ecl_converters
+    uri: https://github.com/yujinrobot-release/ecl_core-release/archive/release/hydro/ecl_converters/0.60.8-0.tar.gz
+    version: ecl_core-release-release-hydro-ecl_converters-0.60.8-0
+- tar:
+    local-name: ecl_core/ecl_devices
+    uri: https://github.com/yujinrobot-release/ecl_core-release/archive/release/hydro/ecl_devices/0.60.8-0.tar.gz
+    version: ecl_core-release-release-hydro-ecl_devices-0.60.8-0
+- tar:
+    local-name: ecl_core/ecl_eigen
+    uri: https://github.com/yujinrobot-release/ecl_core-release/archive/release/hydro/ecl_eigen/0.60.8-0.tar.gz
+    version: ecl_core-release-release-hydro-ecl_eigen-0.60.8-0
+- tar:
+    local-name: ecl_core/ecl_exceptions
+    uri: https://github.com/yujinrobot-release/ecl_core-release/archive/release/hydro/ecl_exceptions/0.60.8-0.tar.gz
+    version: ecl_core-release-release-hydro-ecl_exceptions-0.60.8-0
+- tar:
+    local-name: ecl_core/ecl_formatters
+    uri: https://github.com/yujinrobot-release/ecl_core-release/archive/release/hydro/ecl_formatters/0.60.8-0.tar.gz
+    version: ecl_core-release-release-hydro-ecl_formatters-0.60.8-0
+- tar:
+    local-name: ecl_core/ecl_geometry
+    uri: https://github.com/yujinrobot-release/ecl_core-release/archive/release/hydro/ecl_geometry/0.60.8-0.tar.gz
+    version: ecl_core-release-release-hydro-ecl_geometry-0.60.8-0
+- tar:
+    local-name: ecl_core/ecl_linear_algebra
+    uri: https://github.com/yujinrobot-release/ecl_core-release/archive/release/hydro/ecl_linear_algebra/0.60.8-0.tar.gz
+    version: ecl_core-release-release-hydro-ecl_linear_algebra-0.60.8-0
+- tar:
+    local-name: ecl_core/ecl_math
+    uri: https://github.com/yujinrobot-release/ecl_core-release/archive/release/hydro/ecl_math/0.60.8-0.tar.gz
+    version: ecl_core-release-release-hydro-ecl_math-0.60.8-0
+- tar:
+    local-name: ecl_core/ecl_mpl
+    uri: https://github.com/yujinrobot-release/ecl_core-release/archive/release/hydro/ecl_mpl/0.60.8-0.tar.gz
+    version: ecl_core-release-release-hydro-ecl_mpl-0.60.8-0
+- tar:
+    local-name: ecl_core/ecl_sigslots
+    uri: https://github.com/yujinrobot-release/ecl_core-release/archive/release/hydro/ecl_sigslots/0.60.8-0.tar.gz
+    version: ecl_core-release-release-hydro-ecl_sigslots-0.60.8-0
+- tar:
+    local-name: ecl_core/ecl_streams
+    uri: https://github.com/yujinrobot-release/ecl_core-release/archive/release/hydro/ecl_streams/0.60.8-0.tar.gz
+    version: ecl_core-release-release-hydro-ecl_streams-0.60.8-0
+- tar:
+    local-name: ecl_core/ecl_threads
+    uri: https://github.com/yujinrobot-release/ecl_core-release/archive/release/hydro/ecl_threads/0.60.8-0.tar.gz
+    version: ecl_core-release-release-hydro-ecl_threads-0.60.8-0
+- tar:
+    local-name: ecl_core/ecl_time
+    uri: https://github.com/yujinrobot-release/ecl_core-release/archive/release/hydro/ecl_time/0.60.8-0.tar.gz
+    version: ecl_core-release-release-hydro-ecl_time-0.60.8-0
+- tar:
+    local-name: ecl_core/ecl_type_traits
+    uri: https://github.com/yujinrobot-release/ecl_core-release/archive/release/hydro/ecl_type_traits/0.60.8-0.tar.gz
+    version: ecl_core-release-release-hydro-ecl_type_traits-0.60.8-0
+- tar:
+    local-name: ecl_core/ecl_utilities
+    uri: https://github.com/yujinrobot-release/ecl_core-release/archive/release/hydro/ecl_utilities/0.60.8-0.tar.gz
+    version: ecl_core-release-release-hydro-ecl_utilities-0.60.8-0
+- tar:
+    local-name: ecl_lite/ecl_config
+    uri: https://github.com/yujinrobot-release/ecl_lite-release/archive/release/hydro/ecl_config/0.60.1-0.tar.gz
+    version: ecl_lite-release-release-hydro-ecl_config-0.60.1-0
+- tar:
+    local-name: ecl_lite/ecl_errors
+    uri: https://github.com/yujinrobot-release/ecl_lite-release/archive/release/hydro/ecl_errors/0.60.1-0.tar.gz
+    version: ecl_lite-release-release-hydro-ecl_errors-0.60.1-0
+- tar:
+    local-name: ecl_lite/ecl_time_lite
+    uri: https://github.com/yujinrobot-release/ecl_lite-release/archive/release/hydro/ecl_time_lite/0.60.1-0.tar.gz
+    version: ecl_lite-release-release-hydro-ecl_time_lite-0.60.1-0
+- tar:
+    local-name: ecl_navigation/ecl_mobile_robot
+    uri: https://github.com/yujinrobot-release/ecl_navigation-release/archive/release/hydro/ecl_mobile_robot/0.60.0-2.tar.gz
+    version: ecl_navigation-release-release-hydro-ecl_mobile_robot-0.60.0-2
+- tar:
+    local-name: ecl_tools/ecl_build
+    uri: https://github.com/yujinrobot-release/ecl_tools-release/archive/release/hydro/ecl_build/0.60.1-0.tar.gz
+    version: ecl_tools-release-release-hydro-ecl_build-0.60.1-0
+- tar:
+    local-name: ecl_tools/ecl_license
+    uri: https://github.com/yujinrobot-release/ecl_tools-release/archive/release/hydro/ecl_license/0.60.1-0.tar.gz
+    version: ecl_tools-release-release-hydro-ecl_license-0.60.1-0
+- tar:
+    local-name: gencpp
+    uri: https://github.com/ros-gbp/gencpp-release/archive/release/hydro/gencpp/0.4.17-0.tar.gz
+    version: gencpp-release-release-hydro-gencpp-0.4.17-0
+- tar:
+    local-name: genlisp
+    uri: https://github.com/ros-gbp/genlisp-release/archive/release/hydro/genlisp/0.4.12-0.tar.gz
+    version: genlisp-release-release-hydro-genlisp-0.4.12-0
+- tar:
+    local-name: genmsg
+    uri: https://github.com/ros-gbp/genmsg-release/archive/release/hydro/genmsg/0.4.25-0.tar.gz
+    version: genmsg-release-release-hydro-genmsg-0.4.25-0
+- tar:
+    local-name: genpy
+    uri: https://github.com/ros-gbp/genpy-release/archive/release/hydro/genpy/0.4.16-0.tar.gz
+    version: genpy-release-release-hydro-genpy-0.4.16-0
+- tar:
+    local-name: geometry/kdl_conversions
+    uri: https://github.com/ros-gbp/geometry-release/archive/release/hydro/kdl_conversions/1.10.8-0.tar.gz
+    version: geometry-release-release-hydro-kdl_conversions-1.10.8-0
+- tar:
+    local-name: geometry/tf
+    uri: https://github.com/ros-gbp/geometry-release/archive/release/hydro/tf/1.10.8-0.tar.gz
+    version: geometry-release-release-hydro-tf-1.10.8-0
+- tar:
+    local-name: geometry/tf_conversions
+    uri: https://github.com/ros-gbp/geometry-release/archive/release/hydro/tf_conversions/1.10.8-0.tar.gz
+    version: geometry-release-release-hydro-tf_conversions-1.10.8-0
+- tar:
+    local-name: geometry2/tf2
+    uri: https://github.com/ros-gbp/geometry2-release/archive/release/hydro/tf2/0.4.10-0.tar.gz
+    version: geometry2-release-release-hydro-tf2-0.4.10-0
+- tar:
+    local-name: geometry2/tf2_msgs
+    uri: https://github.com/ros-gbp/geometry2-release/archive/release/hydro/tf2_msgs/0.4.10-0.tar.gz
+    version: geometry2-release-release-hydro-tf2_msgs-0.4.10-0
+- tar:
+    local-name: geometry2/tf2_py
+    uri: https://github.com/ros-gbp/geometry2-release/archive/release/hydro/tf2_py/0.4.10-0.tar.gz
+    version: geometry2-release-release-hydro-tf2_py-0.4.10-0
+- tar:
+    local-name: geometry2/tf2_ros
+    uri: https://github.com/ros-gbp/geometry2-release/archive/release/hydro/tf2_ros/0.4.10-0.tar.gz
+    version: geometry2-release-release-hydro-tf2_ros-0.4.10-0
+- tar:
+    local-name: image_common/camera_calibration_parsers
+    uri: https://github.com/ros-gbp/image_common-release/archive/release/hydro/camera_calibration_parsers/1.11.1-0.tar.gz
+    version: image_common-release-release-hydro-camera_calibration_parsers-1.11.1-0
+- tar:
+    local-name: image_common/camera_info_manager
+    uri: https://github.com/ros-gbp/image_common-release/archive/release/hydro/camera_info_manager/1.11.1-0.tar.gz
+    version: image_common-release-release-hydro-camera_info_manager-1.11.1-0
+- tar:
+    local-name: image_common/image_transport
+    uri: https://github.com/ros-gbp/image_common-release/archive/release/hydro/image_transport/1.11.1-0.tar.gz
+    version: image_common-release-release-hydro-image_transport-1.11.1-0
+- tar:
+    local-name: image_pipeline/depth_image_proc
+    uri: https://github.com/ros-gbp/image_pipeline-release/archive/release/hydro/depth_image_proc/1.11.6-0.tar.gz
+    version: image_pipeline-release-release-hydro-depth_image_proc-1.11.6-0
+- tar:
+    local-name: image_pipeline/image_proc
+    uri: https://github.com/ros-gbp/image_pipeline-release/archive/release/hydro/image_proc/1.11.6-0.tar.gz
+    version: image_pipeline-release-release-hydro-image_proc-1.11.6-0
+- tar:
+    local-name: interactive_markers
+    uri: https://github.com/ros-gbp/interactive_markers-release/archive/release/hydro/interactive_markers/1.10.2-0.tar.gz
+    version: interactive_markers-release-release-hydro-interactive_markers-1.10.2-0
+- tar:
+    local-name: kobuki/kobuki_bumper2pc
+    uri: https://github.com/yujinrobot-release/kobuki-release/archive/release/hydro/kobuki_bumper2pc/0.5.5-1.tar.gz
+    version: kobuki-release-release-hydro-kobuki_bumper2pc-0.5.5-1
+- tar:
+    local-name: kobuki/kobuki_description
+    uri: https://github.com/yujinrobot-release/kobuki-release/archive/release/hydro/kobuki_description/0.5.5-1.tar.gz
+    version: kobuki-release-release-hydro-kobuki_description-0.5.5-1
+- tar:
+    local-name: kobuki/kobuki_keyop
+    uri: https://github.com/yujinrobot-release/kobuki-release/archive/release/hydro/kobuki_keyop/0.5.5-1.tar.gz
+    version: kobuki-release-release-hydro-kobuki_keyop-0.5.5-1
+- tar:
+    local-name: kobuki/kobuki_node
+    uri: https://github.com/yujinrobot-release/kobuki-release/archive/release/hydro/kobuki_node/0.5.5-1.tar.gz
+    version: kobuki-release-release-hydro-kobuki_node-0.5.5-1
+- tar:
+    local-name: kobuki/kobuki_safety_controller
+    uri: https://github.com/yujinrobot-release/kobuki-release/archive/release/hydro/kobuki_safety_controller/0.5.5-1.tar.gz
+    version: kobuki-release-release-hydro-kobuki_safety_controller-0.5.5-1
+- tar:
+    local-name: kobuki_core/kobuki_driver
+    uri: https://github.com/yujinrobot-release/kobuki_core-release/archive/release/hydro/kobuki_driver/0.5.3-0.tar.gz
+    version: kobuki_core-release-release-hydro-kobuki_driver-0.5.3-0
+- tar:
+    local-name: kobuki_core/kobuki_ftdi
+    uri: https://github.com/yujinrobot-release/kobuki_core-release/archive/release/hydro/kobuki_ftdi/0.5.3-0.tar.gz
+    version: kobuki_core-release-release-hydro-kobuki_ftdi-0.5.3-0
+- tar:
+    local-name: kobuki_msgs
+    uri: https://github.com/yujinrobot-release/kobuki_msgs-release/archive/release/hydro/kobuki_msgs/0.5.0-0.tar.gz
+    version: kobuki_msgs-release-release-hydro-kobuki_msgs-0.5.0-0
+- tar:
+    local-name: laser_geometry
+    uri: https://github.com/ros-gbp/laser_geometry-release/archive/release/hydro/laser_geometry/1.5.15-0.tar.gz
+    version: laser_geometry-release-release-hydro-laser_geometry-1.5.15-0
+- tar:
+    local-name: map_msgs
+    uri: https://github.com/ros-gbp/map_msgs-release/archive/release/hydro/map_msgs/0.0.2-0.tar.gz
+    version: map_msgs-release-release-hydro-map_msgs-0.0.2-0
+- tar:
+    local-name: media_export
+    uri: https://github.com/ros-gbp/media_export-release/archive/release/hydro/media_export/0.1.0-0.tar.gz
+    version: media_export-release-release-hydro-media_export-0.1.0-0
+- tar:
+    local-name: message_generation
+    uri: https://github.com/ros-gbp/message_generation-release/archive/release/hydro/message_generation/0.2.10-0.tar.gz
+    version: message_generation-release-release-hydro-message_generation-0.2.10-0
+- tar:
+    local-name: message_runtime
+    uri: https://github.com/ros-gbp/message_runtime-release/archive/release/hydro/message_runtime/0.4.12-0.tar.gz
+    version: message_runtime-release-release-hydro-message_runtime-0.4.12-0
+- tar:
+    local-name: navigation/robot_pose_ekf
+    uri: https://github.com/ros-gbp/navigation-release/archive/release/hydro/robot_pose_ekf/1.11.6-1.tar.gz
+    version: navigation-release-release-hydro-robot_pose_ekf-1.11.6-1
+- tar:
+    local-name: nodelet_core/nodelet
+    uri: https://github.com/ros-gbp/nodelet_core-release/archive/release/hydro/nodelet/1.8.2-0.tar.gz
+    version: nodelet_core-release-release-hydro-nodelet-1.8.2-0
+- tar:
+    local-name: nodelet_core/nodelet_topic_tools
+    uri: https://github.com/ros-gbp/nodelet_core-release/archive/release/hydro/nodelet_topic_tools/1.8.2-0.tar.gz
+    version: nodelet_core-release-release-hydro-nodelet_topic_tools-1.8.2-0
+- tar:
+    local-name: opencv2
+    uri: https://github.com/ros-gbp/opencv2-release/archive/release/hydro/opencv2/2.4.6-3.tar.gz
+    version: opencv2-release-release-hydro-opencv2-2.4.6-3
+- tar:
+    local-name: openni_camera
+    uri: https://github.com/ros-gbp/openni_camera-release/archive/release/hydro/openni_camera/1.9.2-0.tar.gz
+    version: openni_camera-release-release-hydro-openni_camera-1.9.2-0
+- tar:
+    local-name: openni_launch
+    uri: https://github.com/ros-gbp/openni_launch-release/archive/release/hydro/openni_launch/1.9.4-0.tar.gz
+    version: openni_launch-release-release-hydro-openni_launch-1.9.4-0
+- tar:
+    local-name: orocos_kinematics_dynamics/orocos_kdl
+    uri: https://github.com/smits/orocos-kdl-release/archive/release/hydro/orocos_kdl/1.2.2-0.tar.gz
+    version: orocos-kdl-release-release-hydro-orocos_kdl-1.2.2-0
+- tar:
+    local-name: orocos_kinematics_dynamics/python_orocos_kdl
+    uri: https://github.com/smits/orocos-kdl-release/archive/release/hydro/python_orocos_kdl/1.2.2-0.tar.gz
+    version: orocos-kdl-release-release-hydro-python_orocos_kdl-1.2.2-0
+- tar:
+    local-name: pcl_conversions
+    uri: https://github.com/ros-gbp/pcl_conversions-release/archive/release/hydro/pcl_conversions/0.1.5-0.tar.gz
+    version: pcl_conversions-release-release-hydro-pcl_conversions-0.1.5-0
+- tar:
+    local-name: pcl_msgs
+    uri: https://github.com/ros-gbp/pcl_msgs-release/archive/release/hydro/pcl_msgs/0.1.0-0.tar.gz
+    version: pcl_msgs-release-release-hydro-pcl_msgs-0.1.0-0
+- tar:
+    local-name: perception_pcl/pcl_ros
+    uri: https://github.com/ros-gbp/perception_pcl-release/archive/release/hydro/pcl_ros/1.1.7-0.tar.gz
+    version: perception_pcl-release-release-hydro-pcl_ros-1.1.7-0
+- tar:
+    local-name: pluginlib
+    uri: https://github.com/ros-gbp/pluginlib-release/archive/release/hydro/pluginlib/1.9.24-0.tar.gz
+    version: pluginlib-release-release-hydro-pluginlib-1.9.24-0
+- tar:
+    local-name: python_qt_binding
+    uri: https://github.com/ros-gbp/python_qt_binding-release/archive/release/hydro/python_qt_binding/0.2.12-0.tar.gz
+    version: python_qt_binding-release-release-hydro-python_qt_binding-0.2.12-0
+- tar:
+    local-name: rgbd_launch
+    uri: https://github.com/ros-gbp/rgbd_launch-release/archive/release/hydro/rgbd_launch/2.0.1-0.tar.gz
+    version: rgbd_launch-release-release-hydro-rgbd_launch-2.0.1-0
+- tar:
+    local-name: robot_model/kdl_parser
+    uri: https://github.com/ros-gbp/robot_model-release/archive/release/hydro/kdl_parser/1.10.18-1.tar.gz
+    version: robot_model-release-release-hydro-kdl_parser-1.10.18-1
+- tar:
+    local-name: robot_model/resource_retriever
+    uri: https://github.com/ros-gbp/robot_model-release/archive/release/hydro/resource_retriever/1.10.18-1.tar.gz
+    version: robot_model-release-release-hydro-resource_retriever-1.10.18-1
+- tar:
+    local-name: robot_model/urdf
+    uri: https://github.com/ros-gbp/robot_model-release/archive/release/hydro/urdf/1.10.18-1.tar.gz
+    version: robot_model-release-release-hydro-urdf-1.10.18-1
+- tar:
+    local-name: robot_model/urdf_parser_plugin
+    uri: https://github.com/ros-gbp/robot_model-release/archive/release/hydro/urdf_parser_plugin/1.10.18-1.tar.gz
+    version: robot_model-release-release-hydro-urdf_parser_plugin-1.10.18-1
+- tar:
+    local-name: robot_state_publisher
+    uri: https://github.com/ros-gbp/robot_state_publisher-release/archive/release/hydro/robot_state_publisher/1.9.10-0.tar.gz
+    version: robot_state_publisher-release-release-hydro-robot_state_publisher-1.9.10-0
+- tar:
+    local-name: rocon_app_platform/rocon_app_manager
+    uri: https://github.com/yujinrobot-release/rocon_app_platform-release/archive/release/hydro/rocon_app_manager/0.6.1-0.tar.gz
+    version: rocon_app_platform-release-release-hydro-rocon_app_manager-0.6.1-0
+- tar:
+    local-name: rocon_app_platform/rocon_apps
+    uri: https://github.com/yujinrobot-release/rocon_app_platform-release/archive/release/hydro/rocon_apps/0.6.1-0.tar.gz
+    version: rocon_app_platform-release-release-hydro-rocon_apps-0.6.1-0
+- tar:
+    local-name: rocon_msgs/gateway_msgs
+    uri: https://github.com/yujinrobot-release/rocon_msgs-release/archive/release/hydro/gateway_msgs/0.6.9-0.tar.gz
+    version: rocon_msgs-release-release-hydro-gateway_msgs-0.6.9-0
+- tar:
+    local-name: rocon_msgs/rocon_app_manager_msgs
+    uri: https://github.com/yujinrobot-release/rocon_msgs-release/archive/release/hydro/rocon_app_manager_msgs/0.6.9-0.tar.gz
+    version: rocon_msgs-release-release-hydro-rocon_app_manager_msgs-0.6.9-0
+- tar:
+    local-name: rocon_multimaster/redis
+    uri: https://github.com/yujinrobot-release/rocon_multimaster-release/archive/release/hydro/redis/0.6.2-0.tar.gz
+    version: rocon_multimaster-release-release-hydro-redis-0.6.2-0
+- tar:
+    local-name: rocon_multimaster/rocon_gateway
+    uri: https://github.com/yujinrobot-release/rocon_multimaster-release/archive/release/hydro/rocon_gateway/0.6.2-0.tar.gz
+    version: rocon_multimaster-release-release-hydro-rocon_gateway-0.6.2-0
+- tar:
+    local-name: rocon_multimaster/rocon_hub
+    uri: https://github.com/yujinrobot-release/rocon_multimaster-release/archive/release/hydro/rocon_hub/0.6.2-0.tar.gz
+    version: rocon_multimaster-release-release-hydro-rocon_hub-0.6.2-0
+- tar:
+    local-name: rocon_multimaster/rocon_hub_client
+    uri: https://github.com/yujinrobot-release/rocon_multimaster-release/archive/release/hydro/rocon_hub_client/0.6.2-0.tar.gz
+    version: rocon_multimaster-release-release-hydro-rocon_hub_client-0.6.2-0
+- tar:
+    local-name: rocon_multimaster/rocon_utilities
+    uri: https://github.com/yujinrobot-release/rocon_multimaster-release/archive/release/hydro/rocon_utilities/0.6.2-0.tar.gz
+    version: rocon_multimaster-release-release-hydro-rocon_utilities-0.6.2-0
+- tar:
+    local-name: ros/rosbash
+    uri: https://github.com/ros-gbp/ros-release/archive/release/hydro/rosbash/1.10.9-0.tar.gz
+    version: ros-release-release-hydro-rosbash-1.10.9-0
+- tar:
+    local-name: ros/rosbuild
+    uri: https://github.com/ros-gbp/ros-release/archive/release/hydro/rosbuild/1.10.9-0.tar.gz
+    version: ros-release-release-hydro-rosbuild-1.10.9-0
+- tar:
+    local-name: ros/rosclean
+    uri: https://github.com/ros-gbp/ros-release/archive/release/hydro/rosclean/1.10.9-0.tar.gz
+    version: ros-release-release-hydro-rosclean-1.10.9-0
+- tar:
+    local-name: ros/roslang
+    uri: https://github.com/ros-gbp/ros-release/archive/release/hydro/roslang/1.10.9-0.tar.gz
+    version: ros-release-release-hydro-roslang-1.10.9-0
+- tar:
+    local-name: ros/roslib
+    uri: https://github.com/ros-gbp/ros-release/archive/release/hydro/roslib/1.10.9-0.tar.gz
+    version: ros-release-release-hydro-roslib-1.10.9-0
+- tar:
+    local-name: ros/rosunit
+    uri: https://github.com/ros-gbp/ros-release/archive/release/hydro/rosunit/1.10.9-0.tar.gz
+    version: ros-release-release-hydro-rosunit-1.10.9-0
+- tar:
+    local-name: ros_comm/message_filters
+    uri: https://github.com/ros-gbp/ros_comm-release/archive/release/hydro/message_filters/1.10.2-0.tar.gz
+    version: ros_comm-release-release-hydro-message_filters-1.10.2-0
+- tar:
+    local-name: ros_comm/rosbag
+    uri: https://github.com/ros-gbp/ros_comm-release/archive/release/hydro/rosbag/1.10.2-0.tar.gz
+    version: ros_comm-release-release-hydro-rosbag-1.10.2-0
+- tar:
+    local-name: ros_comm/rosbag_storage
+    uri: https://github.com/ros-gbp/ros_comm-release/archive/release/hydro/rosbag_storage/1.10.2-0.tar.gz
+    version: ros_comm-release-release-hydro-rosbag_storage-1.10.2-0
+- tar:
+    local-name: ros_comm/rosconsole
+    uri: https://github.com/ros-gbp/ros_comm-release/archive/release/hydro/rosconsole/1.10.2-0.tar.gz
+    version: ros_comm-release-release-hydro-rosconsole-1.10.2-0
+- tar:
+    local-name: ros_comm/roscpp
+    uri: https://github.com/ros-gbp/ros_comm-release/archive/release/hydro/roscpp/1.10.2-0.tar.gz
+    version: ros_comm-release-release-hydro-roscpp-1.10.2-0
+- tar:
+    local-name: ros_comm/rosgraph
+    uri: https://github.com/ros-gbp/ros_comm-release/archive/release/hydro/rosgraph/1.10.2-0.tar.gz
+    version: ros_comm-release-release-hydro-rosgraph-1.10.2-0
+- tar:
+    local-name: ros_comm/rosgraph_msgs
+    uri: https://github.com/ros-gbp/ros_comm-release/archive/release/hydro/rosgraph_msgs/1.10.2-0.tar.gz
+    version: ros_comm-release-release-hydro-rosgraph_msgs-1.10.2-0
+- tar:
+    local-name: ros_comm/roslaunch
+    uri: https://github.com/ros-gbp/ros_comm-release/archive/release/hydro/roslaunch/1.10.2-0.tar.gz
+    version: ros_comm-release-release-hydro-roslaunch-1.10.2-0
+- tar:
+    local-name: ros_comm/rosmaster
+    uri: https://github.com/ros-gbp/ros_comm-release/archive/release/hydro/rosmaster/1.10.2-0.tar.gz
+    version: ros_comm-release-release-hydro-rosmaster-1.10.2-0
+- tar:
+    local-name: ros_comm/rosmsg
+    uri: https://github.com/ros-gbp/ros_comm-release/archive/release/hydro/rosmsg/1.10.2-0.tar.gz
+    version: ros_comm-release-release-hydro-rosmsg-1.10.2-0
+- tar:
+    local-name: ros_comm/rosnode
+    uri: https://github.com/ros-gbp/ros_comm-release/archive/release/hydro/rosnode/1.10.2-0.tar.gz
+    version: ros_comm-release-release-hydro-rosnode-1.10.2-0
+- tar:
+    local-name: ros_comm/rosout
+    uri: https://github.com/ros-gbp/ros_comm-release/archive/release/hydro/rosout/1.10.2-0.tar.gz
+    version: ros_comm-release-release-hydro-rosout-1.10.2-0
+- tar:
+    local-name: ros_comm/rosparam
+    uri: https://github.com/ros-gbp/ros_comm-release/archive/release/hydro/rosparam/1.10.2-0.tar.gz
+    version: ros_comm-release-release-hydro-rosparam-1.10.2-0
+- tar:
+    local-name: ros_comm/rospy
+    uri: https://github.com/ros-gbp/ros_comm-release/archive/release/hydro/rospy/1.10.2-0.tar.gz
+    version: ros_comm-release-release-hydro-rospy-1.10.2-0
+- tar:
+    local-name: ros_comm/rosservice
+    uri: https://github.com/ros-gbp/ros_comm-release/archive/release/hydro/rosservice/1.10.2-0.tar.gz
+    version: ros_comm-release-release-hydro-rosservice-1.10.2-0
+- tar:
+    local-name: ros_comm/rostest
+    uri: https://github.com/ros-gbp/ros_comm-release/archive/release/hydro/rostest/1.10.2-0.tar.gz
+    version: ros_comm-release-release-hydro-rostest-1.10.2-0
+- tar:
+    local-name: ros_comm/rostopic
+    uri: https://github.com/ros-gbp/ros_comm-release/archive/release/hydro/rostopic/1.10.2-0.tar.gz
+    version: ros_comm-release-release-hydro-rostopic-1.10.2-0
+- tar:
+    local-name: ros_comm/roswtf
+    uri: https://github.com/ros-gbp/ros_comm-release/archive/release/hydro/roswtf/1.10.2-0.tar.gz
+    version: ros_comm-release-release-hydro-roswtf-1.10.2-0
+- tar:
+    local-name: ros_comm/std_srvs
+    uri: https://github.com/ros-gbp/ros_comm-release/archive/release/hydro/std_srvs/1.10.2-0.tar.gz
+    version: ros_comm-release-release-hydro-std_srvs-1.10.2-0
+- tar:
+    local-name: ros_comm/topic_tools
+    uri: https://github.com/ros-gbp/ros_comm-release/archive/release/hydro/topic_tools/1.10.2-0.tar.gz
+    version: ros_comm-release-release-hydro-topic_tools-1.10.2-0
+- tar:
+    local-name: ros_comm/xmlrpcpp
+    uri: https://github.com/ros-gbp/ros_comm-release/archive/release/hydro/xmlrpcpp/1.10.2-0.tar.gz
+    version: ros_comm-release-release-hydro-xmlrpcpp-1.10.2-0
+- tar:
+    local-name: ros_tutorials/rospy_tutorials
+    uri: https://github.com/ros-gbp/ros_tutorials-release/archive/release/hydro/rospy_tutorials/0.4.3-0.tar.gz
+    version: ros_tutorials-release-release-hydro-rospy_tutorials-0.4.3-0
+- tar:
+    local-name: rosconsole_bridge
+    uri: https://github.com/ros-gbp/rosconsole_bridge-release/archive/release/hydro/rosconsole_bridge/0.3.4-0.tar.gz
+    version: rosconsole_bridge-release-release-hydro-rosconsole_bridge-0.3.4-0
+- tar:
+    local-name: roscpp_core/cpp_common
+    uri: https://github.com/ros-gbp/roscpp_core-release/archive/release/hydro/cpp_common/0.4.3-0.tar.gz
+    version: roscpp_core-release-release-hydro-cpp_common-0.4.3-0
+- tar:
+    local-name: roscpp_core/roscpp_serialization
+    uri: https://github.com/ros-gbp/roscpp_core-release/archive/release/hydro/roscpp_serialization/0.4.3-0.tar.gz
+    version: roscpp_core-release-release-hydro-roscpp_serialization-0.4.3-0
+- tar:
+    local-name: roscpp_core/roscpp_traits
+    uri: https://github.com/ros-gbp/roscpp_core-release/archive/release/hydro/roscpp_traits/0.4.3-0.tar.gz
+    version: roscpp_core-release-release-hydro-roscpp_traits-0.4.3-0
+- tar:
+    local-name: roscpp_core/rostime
+    uri: https://github.com/ros-gbp/roscpp_core-release/archive/release/hydro/rostime/0.4.3-0.tar.gz
+    version: roscpp_core-release-release-hydro-rostime-0.4.3-0
+- tar:
+    local-name: rospack
+    uri: https://github.com/ros-gbp/rospack-release/archive/release/hydro/rospack/2.1.23-0.tar.gz
+    version: rospack-release-release-hydro-rospack-2.1.23-0
+- tar:
+    local-name: rviz
+    uri: https://github.com/ros-gbp/rviz-release/archive/release/hydro/rviz/1.10.14-0.tar.gz
+    version: rviz-release-release-hydro-rviz-1.10.14-0
+- tar:
+    local-name: std_msgs
+    uri: https://github.com/ros-gbp/std_msgs-release/archive/release/hydro/std_msgs/0.5.8-0.tar.gz
+    version: std_msgs-release-release-hydro-std_msgs-0.5.8-0
+- tar:
+    local-name: turtlebot/linux_hardware
+    uri: https://github.com/turtlebot-release/turtlebot-release/archive/release/hydro/linux_hardware/2.2.3-0.tar.gz
+    version: turtlebot-release-release-hydro-linux_hardware-2.2.3-0
+- tar:
+    local-name: turtlebot/turtlebot_description
+    uri: https://github.com/turtlebot-release/turtlebot-release/archive/release/hydro/turtlebot_description/2.2.3-0.tar.gz
+    version: turtlebot-release-release-hydro-turtlebot_description-2.2.3-0
+- tar:
+    local-name: turtlebot_create/create_description
+    uri: https://github.com/turtlebot-release/turtlebot_create-release/archive/release/hydro/create_description/2.2.0-0.tar.gz
+    version: turtlebot_create-release-release-hydro-create_description-2.2.0-0
+- tar:
+    local-name: turtlebot_create/create_driver
+    uri: https://github.com/turtlebot-release/turtlebot_create-release/archive/release/hydro/create_driver/2.2.0-0.tar.gz
+    version: turtlebot_create-release-release-hydro-create_driver-2.2.0-0
+- tar:
+    local-name: turtlebot_create/create_node
+    uri: https://github.com/turtlebot-release/turtlebot_create-release/archive/release/hydro/create_node/2.2.0-0.tar.gz
+    version: turtlebot_create-release-release-hydro-create_node-2.2.0-0
+- tar:
+    local-name: urdfdom
+    uri: https://github.com/ros-gbp/urdfdom-release/archive/release/hydro/urdfdom/0.2.10-3.tar.gz
+    version: urdfdom-release-release-hydro-urdfdom-0.2.10-3
+- tar:
+    local-name: urdfdom_headers
+    uri: https://github.com/ros-gbp/urdfdom_headers-release/archive/release/hydro/urdfdom_headers/0.2.3-1.tar.gz
+    version: urdfdom_headers-release-release-hydro-urdfdom_headers-0.2.3-1
+- tar:
+    local-name: vision_opencv/cv_bridge
+    uri: https://github.com/ros-gbp/vision_opencv-release/archive/release/hydro/cv_bridge/1.10.15-0.tar.gz
+    version: vision_opencv-release-release-hydro-cv_bridge-1.10.15-0
+- tar:
+    local-name: vision_opencv/image_geometry
+    uri: https://github.com/ros-gbp/vision_opencv-release/archive/release/hydro/image_geometry/1.10.15-0.tar.gz
+    version: vision_opencv-release-release-hydro-image_geometry-1.10.15-0
+- tar:
+    local-name: xacro
+    uri: https://github.com/ros-gbp/xacro-release/archive/release/hydro/xacro/1.8.4-0.tar.gz
+    version: xacro-release-release-hydro-xacro-1.8.4-0
+- tar:
+    local-name: yujin_ocs/yocs_cmd_vel_mux
+    uri: https://github.com/yujinrobot-release/yujin_ocs-release/archive/release/hydro/yocs_cmd_vel_mux/0.5.3-0.tar.gz
+    version: yujin_ocs-release-release-hydro-yocs_cmd_vel_mux-0.5.3-0
+- tar:
+    local-name: yujin_ocs/yocs_controllers
+    uri: https://github.com/yujinrobot-release/yujin_ocs-release/archive/release/hydro/yocs_controllers/0.5.3-0.tar.gz
+    version: yujin_ocs-release-release-hydro-yocs_controllers-0.5.3-0
+- tar:
+    local-name: yujin_ocs/yocs_velocity_smoother
+    uri: https://github.com/yujinrobot-release/yujin_ocs-release/archive/release/hydro/yocs_velocity_smoother/0.5.3-0.tar.gz
+    version: yujin_ocs-release-release-hydro-yocs_velocity_smoother-0.5.3-0
+- tar:
+    local-name: zeroconf_avahi_suite/zeroconf_avahi
+    uri: https://github.com/yujinrobot-release/zeroconf_avahi_suite-release/archive/release/hydro/zeroconf_avahi/0.2.3-0.tar.gz
+    version: zeroconf_avahi_suite-release-release-hydro-zeroconf_avahi-0.2.3-0
+- tar:
+    local-name: zeroconf_msgs
+    uri: https://github.com/yujinrobot-release/zeroconf_msgs-release/archive/release/hydro/zeroconf_msgs/0.2.1-0.tar.gz
+    version: zeroconf_msgs-release-release-hydro-zeroconf_msgs-0.2.1-0
+

--- a/turtlebot/3e32933/test.sh
+++ b/turtlebot/3e32933/test.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+rostest turtlebot_bringup bug_witness.test


### PR DESCRIPTION
Reproduced Turtlebot bug 3e32933.

This is an L2 reproduction. The original bug is in a launch file which spawns hardware-related nodes that are not relevant for the bug reproduction itself.
As such, the `bug_witness.test` for this case contains the relevant slice of the affected launch file.