### PR TITLE
dab1b8a: add GH PR link

### DIFF
--- a/mavros/dab1b8a/dab1b8a.bug
+++ b/mavros/dab1b8a/dab1b8a.bug
@@ -30,7 +30,7 @@ bug:
 fix:
   repo: https://github.com/mavlink/mavros
   hash: dab1b8a16d6194056cb7e76215ecf299d1a90f08
-  pull-request: N/A
+  pull-request: https://github.com/mavlink/mavros/pull/230
   license:
     - BSD
     - GPLv3


### PR DESCRIPTION
As per subject.

Noticed that there is actually a PR the fix commit is contained in.
