### PR TITLE
Fixed build-rosinstall.py to fail cleanly if time machine fails

### DIFF
--- a/scripts/build-rosinstall.py
+++ b/scripts/build-rosinstall.py
@@ -58,9 +58,10 @@ def _time_machine(packages,
                              stdout=subprocess.PIPE)
         contents = res.stdout.decode('utf-8')
     except subprocess.CalledProcessError as err:
-        logger.warning("time machine failed (return code: %d)",
-                       err.returncode)
-        return
+        m = "ERROR: time machine failed (return code: {})"
+        m = m.format(err.returncode)
+        print(m)
+        sys.exit(1)
 
     return {e['tar']['local-name']: e['tar'] for e in yaml.safe_load(contents)}
 


### PR DESCRIPTION
In the event of time machine failure, `build-rosinstall.py` would terminate uncleanly:
```
(robust) chris@chris-MS-7B77:~/bugs/robust$ python scripts/build-rosinstall.py mavros/2998e9f/
building rosinstall files for directory: mavros/2998e9f/
building rosinstall file for file: mavros/2998e9f/2998e9f.bug
executing command: rosinstall_generator_tm.sh 2014-01-14T06:50:54+04:00Z hydro mavros --deps --tar --deps-only
Creating rgtm base dir ..
Need to clone rosdistro .. done
Need to retrieve some rosdistro caches ..done
date: invalid date ‘2014-01-14T06:50:54+04:00Z’
time machine failed (return code: 1)
failed to create rosinstall file for bug: mavros/2998e9f/2998e9f.bug
Traceback (most recent call last):
  File "scripts/build-rosinstall.py", line 166, in build_dir
    build_file(fn, overwrite=overwrite)
  File "scripts/build-rosinstall.py", line 119, in build_file
    deps.update(_time_machine(ros_pkgs, dt, distro, deps_only=True))
TypeError: 'NoneType' object is not iterable
```

This fix now leads `build-rosinstall.py` to terminate cleanly and to better indicate the failure:
```
(robust) chris@chris-MS-7B77:~/bugs/robust$ python scripts/build-rosinstall.py mavros/2998e9f/
building rosinstall files for directory: mavros/2998e9f/
building rosinstall file for file: mavros/2998e9f/2998e9f.bug
executing command: rosinstall_generator_tm.sh 2014-01-14T06:50:54+04:00Z hydro mavros --deps --tar --deps-only
date: invalid date ‘2014-01-14T06:50:54+04:00Z’
ERROR: time machine failed (return code: 1)
```