### PR TITLE
Remove timezone info in build-rosinstall.py to ensure time machine compatibility

### DIFF
--- a/scripts/build-rosinstall.py
+++ b/scripts/build-rosinstall.py
@@ -101,7 +101,7 @@ def build_file(fn_bug_desc, overwrite=False):
     missing_deps = d['time-machine'].get('missing-dependencies', [])
 
     if 'datetime' in d['time-machine']:
-        dt = d['time-machine']['datetime'].isoformat()
+        dt = d['time-machine']['datetime'].replace(tzinfo=None).isoformat()
         if dt[-1] != 'Z':
             dt += 'Z'
     elif 'issue' in d['time-machine']:


### PR DESCRIPTION
Before the fix:
```
(robust) chris@chris-MS-7B77:~/bugs/robust$ python scripts/build-rosinstall.py mavros/2998e9f/
building rosinstall files for directory: mavros/2998e9f/
building rosinstall file for file: mavros/2998e9f/2998e9f.bug
executing command: rosinstall_generator_tm.sh 2014-01-14T06:50:54+04:00Z hydro mavros --deps --tar --deps-only
date: invalid date ‘2014-01-14T06:50:54+04:00Z’
ERROR: time machine failed (return code: 1)
```

After the fix:
```
(robust) chris@chris-MS-7B77:~/bugs/robust$ python scripts/build-rosinstall.py mavros/2998e9f/
building rosinstall files for directory: mavros/2998e9f/
building rosinstall file for file: mavros/2998e9f/2998e9f.bug
executing command: rosinstall_generator_tm.sh 2014-01-14T06:50:54Z hydro mavros --deps --tar --deps-only
Requested timepoint: '2014-01-14T06:50:54Z' (1389682254)
Switching to pre-REP-141 infrastructure ..
Resetting local rosdistro clone ..
```