### PR TITLE
Revert "Remove timezone info in build-rosinstall.py to ensure time machine compatibility"

### DIFF
--- a/scripts/build-rosinstall.py
+++ b/scripts/build-rosinstall.py
@@ -101,7 +101,7 @@ def build_file(fn_bug_desc, overwrite=False):
     missing_deps = d['time-machine'].get('missing-dependencies', [])
 
     if 'datetime' in d['time-machine']:
-        dt = d['time-machine']['datetime'].replace(tzinfo=None).isoformat()
+        dt = d['time-machine']['datetime'].isoformat()
         if dt[-1] != 'Z':
             dt += 'Z'
     elif 'issue' in d['time-machine']:


### PR DESCRIPTION
Reverts robust-rosin/robust#348

We cannot ignore timezones.

If parsing fails, we should fix the date in the `.bug`.

See also my comments in #348.
