### PR TITLE
Added support for missing system dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -146,7 +146,7 @@ RUN echo "[ROBUST] creating build script" \
 COPY deps.rosinstall .
 RUN wstool init -j8 ${ROS_WSPACE}/src ${ROS_WSPACE}/deps.rosinstall
 
-# install binary dependencies via rosdep
+# install binary dependencies via rosdep and apt
 ARG MISSING_SYSTEM_DEPENDENCIES
 RUN apt-get clean \
  && apt-get update \
@@ -157,7 +157,7 @@ RUN apt-get clean \
  && (test -z "${MISSING_SYSTEM_DEPENDENCIES}" \
      && echo "no missing system dependencies need to be installed" \
      || (echo "installing missing system dependencies: ${MISSING_SYSTEM_DEPENDENCIES}" \
-         && rosdep install -y ${MISSING_SYSTEM_DEPENDENCIES})) \
+         && apt install -y --no-install-recommends ${MISSING_SYSTEM_DEPENDENCIES})) \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* \
  && cd /usr/src/gtest \

--- a/Dockerfile
+++ b/Dockerfile
@@ -157,7 +157,7 @@ RUN apt-get clean \
  && (test -z "${MISSING_SYSTEM_DEPENDENCIES}" \
      && echo "no missing system dependencies need to be installed" \
      || (echo "installing missing system dependencies: ${MISSING_SYSTEM_DEPENDENCIES}" \
-         && apt install -y --no-install-recommends ${MISSING_SYSTEM_DEPENDENCIES})) \
+         && apt-get install -y --no-install-recommends ${MISSING_SYSTEM_DEPENDENCIES})) \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* \
  && cd /usr/src/gtest \

--- a/Dockerfile
+++ b/Dockerfile
@@ -147,12 +147,16 @@ COPY deps.rosinstall .
 RUN wstool init -j8 ${ROS_WSPACE}/src ${ROS_WSPACE}/deps.rosinstall
 
 # install binary dependencies via rosdep
+ARG MISSING_SYSTEM_DEPENDENCIES
 RUN apt-get clean \
  && apt-get update \
  && rosdep init \
  && rosdep update \
  && rosdep install --from-paths src -i --rosdistro=${ROS_DISTRO} -y \
       --skip-keys="python-rosdep python-catkin-pkg python-rospkg" \
+ && ([-z "${MISSING_SYSTEM_DEPENDENCIES}"] \
+      && echo "installing missing system dependencies: ${MISSING_SYSTEM_DEPENDENCIES}" \
+      && rosdep install -y ${MISSING_SYSTEM_DEPENDENCIES}) \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* \
  && cd /usr/src/gtest \

--- a/Dockerfile
+++ b/Dockerfile
@@ -154,9 +154,10 @@ RUN apt-get clean \
  && rosdep update \
  && rosdep install --from-paths src -i --rosdistro=${ROS_DISTRO} -y \
       --skip-keys="python-rosdep python-catkin-pkg python-rospkg" \
- && ([-z "${MISSING_SYSTEM_DEPENDENCIES}"] \
-      && echo "installing missing system dependencies: ${MISSING_SYSTEM_DEPENDENCIES}" \
-      && rosdep install -y ${MISSING_SYSTEM_DEPENDENCIES}) \
+ && (test -z "${MISSING_SYSTEM_DEPENDENCIES}" \
+     && echo "no missing system dependencies need to be installed" \
+     || (echo "installing missing system dependencies: ${MISSING_SYSTEM_DEPENDENCIES}" \
+         && rosdep install -y ${MISSING_SYSTEM_DEPENDENCIES})) \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* \
  && cd /usr/src/gtest \

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -111,7 +111,7 @@ are modified in order to break the cache and to ensure the image is up to date.
 * `use-osrf` [optional]: whether or not BugZoo should use OSRF's sources when installing dependencies for the PUT. If `use-osrf` is not provided, its value will default to `no` (i.e., OSRF
 sources will not be used).
 * `missing-system-dependencies` [optional]: gives a list of the names of any
-  missing system dependencies that should be installed via rosdep (for both
+  missing system dependencies that should be installed via `apt-get` (for both
   the buggy and fixed images).
 
 **Note:** To use this script, `pyyaml` must be installed in the current

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -110,6 +110,9 @@ are modified in order to break the cache and to ensure the image is up to date.
 * `fork-urls`: lists the url(s) of the forked repository(/ies).
 * `use-osrf` [optional]: whether or not BugZoo should use OSRF's sources when installing dependencies for the PUT. If `use-osrf` is not provided, its value will default to `no` (i.e., OSRF
 sources will not be used).
+* `missing-system-dependencies` [optional]: gives a list of the names of any
+  missing system dependencies that should be installed via rosdep (for both
+  the buggy and fixed images).
 
 **Note:** To use this script, `pyyaml` must be installed in the current
   environment.

--- a/scripts/build-bugzoo.py
+++ b/scripts/build-bugzoo.py
@@ -49,6 +49,7 @@ def main():
             sha_bug = desc['bugzoo']['bug-commit']
             sha_fix = desc['bugzoo']['fix-commit']
             url_forks = desc['bugzoo']['fork-urls']
+            missing_system_deps = desc['bugzoo'].get('missing-system-dependencies', [])
         except KeyError as err:
             report_error('missing property [{}]'.format(err))
             continue
@@ -67,12 +68,16 @@ def main():
             report_error("'is_build_failure' should be a boolean")
             continue
 
+        if not isinstance(missing_system_deps, list):
+            report_error("'bugzoo.missing-system-dependencies' should be a list")
+            continue
+
         if not isinstance(url_forks, list):
             report_error("'bugzoo.url-forks' should be a list")
             continue
 
         if len(url_forks) > 1:
-            report_error("BugZoo file does not support multiple forks.")
+            report_error("BugZoo file does not support multiple forks")
             continue
 
         # determine Ubuntu version based on ROS distro
@@ -98,9 +103,10 @@ def main():
             'UBUNTU_VERSION': ubuntu_version,
             'ROS_DISTRO': ros_distro,
             'CATKIN_PACKAGES': ' '.join(ros_pkgs),
+            'MISSING_SYSTEM_DEPENDENCIES': ' '.join(missing_system_deps),
             'REPO_FORK_URL': url_forks[0],  # FIXME
             'REPO_BUG_COMMIT': sha_bug,
-            'REPO_FIX_COMMIT': sha_fix
+            'REPO_FIX_COMMIT': sha_fix,
         }
 
         # create a separate blueprint for the buggy and fixed version

--- a/scripts/build-bugzoo.py
+++ b/scripts/build-bugzoo.py
@@ -106,7 +106,7 @@ def main():
             'MISSING_SYSTEM_DEPENDENCIES': ' '.join(missing_system_deps),
             'REPO_FORK_URL': url_forks[0],  # FIXME
             'REPO_BUG_COMMIT': sha_bug,
-            'REPO_FIX_COMMIT': sha_fix,
+            'REPO_FIX_COMMIT': sha_fix
         }
 
         # create a separate blueprint for the buggy and fixed version


### PR DESCRIPTION
Missing system dependencies can now be specified using a list in the `bugzoo.missing-system-dependencies` property.