### PR TITLE
Only append Z to timestamp when there is no timezone info (build-rosinstall.py)

### DIFF
--- a/scripts/build-rosinstall.py
+++ b/scripts/build-rosinstall.py
@@ -101,13 +101,14 @@ def build_file(fn_bug_desc, overwrite=False):
     missing_deps = d['time-machine'].get('missing-dependencies', [])
 
     if 'datetime' in d['time-machine']:
-        dt = d['time-machine']['datetime'].isoformat()
-        if dt[-1] != 'Z':
-            dt += 'Z'
+        dt = d['time-machine']['datetime']
+        dt_string = dt.isoformat()
+        if not dt.tzinfo and dt_string[-1] != 'Z':
+            dt_string += 'Z'
     elif 'issue' in d['time-machine']:
         url_issue = d['time-machine']['issue']
         try:
-            dt = gh_issue_to_datetime(url_issue)
+            dt_string = gh_issue_to_datetime(url_issue)
         except Exception:
             m = "failed to convert GitHub issue to ISO 8601 timestamp: {}"
             m = m.format(url_issue)
@@ -117,9 +118,9 @@ def build_file(fn_bug_desc, overwrite=False):
 
     try:
         deps = {}
-        deps.update(_time_machine(ros_pkgs, dt, distro, deps_only=True))
+        deps.update(_time_machine(ros_pkgs, dt_string, distro, deps_only=True))
         if missing_deps:
-            deps.update(_time_machine(missing_deps, dt, distro, deps_only=False))
+            deps.update(_time_machine(missing_deps, dt_string, distro, deps_only=False))
     except subprocess.CalledProcessError as err:
         logger.warning("time machine failed (return code: %d) for bug [%s]",
                        err.returncode, fn_bug_desc)


### PR DESCRIPTION
Time machine output after applying fix:
```
(robust) chris@chris-MS-7B77:~/bugs/robust$ python scripts/build-rosinstall.py mavros/2998e9f/
building rosinstall files for directory: mavros/2998e9f/
building rosinstall file for file: mavros/2998e9f/2998e9f.bug
executing command: rosinstall_generator_tm.sh 2014-01-14T06:50:54+04:00 hydro mavros --deps --tar --deps-only
Requested timepoint: '2014-01-14T06:50:54+04:00' (1389667854)
Switching to pre-REP-141 infrastructure ..
Resetting local rosdistro clone ..
Previous HEAD position was 45edff248 Merge pull request #2866 from stonier/bloom-turtlebot-1
Switched to branch 'master'
```