### PR TITLE
Updated bug description files to support multiple fix commits (fixes #379)

### DIFF
--- a/care-o-bot/0000000/0000000.bug
+++ b/care-o-bot/0000000/0000000.bug
@@ -1,6 +1,6 @@
 %YAML 1.1
 ---
-id: 0
+id: "0000000"
 title: Individual ROS-packages of Metapackage are outdated on local system
 description: >
   The motor for the tray of CoB-3 is not moving. The reason for the
@@ -36,8 +36,9 @@ bug:
   reproducibility: rare
   trace: null
 fix:
-  repo: https://github.com/ipa320/cob_robots/tree/indigo_dev/cob_bringup
-  hash: null   # The previous one would be: 0656d117ba875221c66a5e354252d06c2562aced
+  commits: []
+  # repo: https://github.com/ipa320/cob_robots/tree/indigo_dev/cob_bringup
+  # The previous commit would be: 0656d117ba875221c66a5e354252d06c2562aced
   pull-request: null
   license: ['LGPL']
   fix-in: []

--- a/care-o-bot/0000000/0000000.bug
+++ b/care-o-bot/0000000/0000000.bug
@@ -1,6 +1,6 @@
 %YAML 1.1
 ---
-id: 0000000
+id: 0
 title: Individual ROS-packages of Metapackage are outdated on local system
 description: >
   The motor for the tray of CoB-3 is not moving. The reason for the

--- a/care-o-bot/105dc16/105dc16.bug
+++ b/care-o-bot/105dc16/105dc16.bug
@@ -37,8 +37,6 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/ipa320/cob_control
-  hash: 105dc16ffe0b9dba294aabea0c18052cd281bde0
   pull-request: https://github.com/thiagodefreitas/cob_control/commit/105dc16ffe0b9dba294aabea0c18052cd281bde0
   license: ['LGPL']
   fix-in:
@@ -46,3 +44,6 @@ fix:
   languages:
     - CMake
   time: 2014-11-21 (12:57)
+  commits:
+    - repo: https://github.com/ipa320/cob_control
+      hash: 105dc16ffe0b9dba294aabea0c18052cd281bde0

--- a/care-o-bot/1518978/1518978.bug
+++ b/care-o-bot/1518978/1518978.bug
@@ -36,11 +36,12 @@ bug:
   reproducibility: sometimes
   trace: null
 fix:
-  repo: https://github.com/ipa320/cob_driver
-  hash: 151897840540e8dd662cf6c8c77e5613c84e3424
   pull-request: https://github.com/ipa320/cob_driver/pull/274
   license: ['LGPL']
   fix-in: ['https://github.com/ipa-fxm/cob_driver/blob/151897840540e8dd662cf6c8c77e5613c84e3424/cob_sound/ros/src/sound.cpp']
   languages:
     - C++
   time: 2016-04-07 (00:00)
+  commits:
+    - repo: https://github.com/ipa320/cob_driver
+      hash: 151897840540e8dd662cf6c8c77e5613c84e3424

--- a/care-o-bot/28c23cd/28c23cd.bug
+++ b/care-o-bot/28c23cd/28c23cd.bug
@@ -36,8 +36,6 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/ipa320/cob_command_tools
-  hash: 28c23cd13e5cbade9776b496518facc07cef59f2
   pull-request: https://github.com/ipa320/cob_command_tools/pull/127
   license: ['LGPL']
   fix-in:
@@ -45,3 +43,6 @@ fix:
   languages:
     - CMake
   time: 2015-11-24 (19:36)
+  commits:
+    - repo: https://github.com/ipa320/cob_command_tools
+      hash: 28c23cd13e5cbade9776b496518facc07cef59f2

--- a/care-o-bot/43705f7/43705f7.bug
+++ b/care-o-bot/43705f7/43705f7.bug
@@ -35,11 +35,12 @@ bug:
   reproducibility: sometimes
   trace: null
 fix:
-  repo: https://github.com/ipa320/cob_common
-  hash: 43705f74847ce09edb971adb50d9e47
   pull-request: https://github.com/ipa320/cob_common/pull/179
   license: ['LGPL']
   fix-in: ['https://github.com/ipa320/cob_common/pull/179/commits/43705f74847ce09edb971adb50d9e47b14f944cf']
   languages:
     - Xacro
   time: 2015-11-20 (00:00)
+  commits:
+    - repo: https://github.com/ipa320/cob_common
+      hash: 43705f74847ce09edb971adb50d9e47

--- a/care-o-bot/79867c8/79867c8.bug
+++ b/care-o-bot/79867c8/79867c8.bug
@@ -42,8 +42,6 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/ipa320/cob_android
-  hash: 79867c88acc64342f061e6324ed6b84ca7e0773d
   pull-request: https://github.com/ipa320/cob_android/pull/8
   license: ['LGPL']
   fix-in:
@@ -52,3 +50,6 @@ fix:
   languages:
     - CMake
   time: 2015-08-04 (16:26)
+  commits:
+    - repo: https://github.com/ipa320/cob_android
+      hash: 79867c88acc64342f061e6324ed6b84ca7e0773d

--- a/care-o-bot/ac6a181/ac6a181.bug
+++ b/care-o-bot/ac6a181/ac6a181.bug
@@ -31,8 +31,6 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/ipa320/cob_command_tools
-  hash: 81aa175d76608fbac6655ce745e8eaa1d35f51f9
   pull-request: https://github.com/ipa320/cob_command_tools/pull/50 # large PR, fix commit is part of it
   license: ['LGPL']
   fix-in:
@@ -40,3 +38,6 @@ fix:
   languages:
     - Package XML
   time: 2014-08-26 (08:57)
+  commits:
+    - repo: https://github.com/ipa320/cob_command_tools
+      hash: 81aa175d76608fbac6655ce745e8eaa1d35f51f9

--- a/care-o-bot/b826eae/b826eae.bug
+++ b/care-o-bot/b826eae/b826eae.bug
@@ -37,11 +37,12 @@ bug:
   reproducibility: sometimes
   trace: null
 fix:
-  repo: https://github.com/ipa320/cob_robots
-  hash: b826eaeae5c8dc548ac2c97002725c7a8131137e
   pull-request: https://github.com/ipa320/cob_robots/pull/553
   license: ['LGPL']
   fix-in: ['https://github.com/ipa-fmw/cob_robots/blob/b826eaeae5c8dc548ac2c97002725c7a8131137e/cob_hardware_config/cob3-9/urdf/cob3-9.urdf.xacro']
   languages:
     - Xacro
   time: 2016-11-10 (00:00)
+  commits:
+    - repo: https://github.com/ipa320/cob_robots
+      hash: b826eaeae5c8dc548ac2c97002725c7a8131137e

--- a/care-o-bot/c8091b6/c8091b6.bug
+++ b/care-o-bot/c8091b6/c8091b6.bug
@@ -32,8 +32,6 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/ipa320/cob_command_tools
-  hash: c8091b68c69eeae0bb7777ad6fa44d644c20f96c
   pull-request: https://github.com/ipa320/cob_command_tools/pull/84
   license: ['LGPL']
   fix-in:
@@ -41,3 +39,6 @@ fix:
   languages:
     - Python
   time: 2015-03-13 (16:21)
+  commits:
+    - repo: https://github.com/ipa320/cob_command_tools
+      hash: c8091b68c69eeae0bb7777ad6fa44d644c20f96c

--- a/care-o-bot/ca7b536/ca7b536.bug
+++ b/care-o-bot/ca7b536/ca7b536.bug
@@ -38,8 +38,6 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/ipa320/cob_control
-  hash: ca7b536390bcf76bf4ab6e62354c52bd51fb1ece
   pull-request: https://github.com/ipa320/cob_control/pull/47
   license: ['LGPL']
   fix-in:
@@ -47,3 +45,6 @@ fix:
   languages:
     - CMake
   time: 2015-08-04 (13:09)
+  commits:
+    - repo: https://github.com/ipa320/cob_control
+      hash: ca7b536390bcf76bf4ab6e62354c52bd51fb1ece

--- a/care-o-bot/e9ed0f8/e9ed0f8.bug
+++ b/care-o-bot/e9ed0f8/e9ed0f8.bug
@@ -39,8 +39,6 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/ros-simulation/gazebo_ros_pkgs
-  hash: e9ed0f8e157398621987bd61e2d78683cd945c2b
   pull-request: https://github.com/ros-simulation/gazebo_ros_pkgs/pull/343
   license: ['LGPL']
   fix-in:
@@ -50,3 +48,6 @@ fix:
     - CMake
     - Package XML
   time: 2015-08-08 (10:05)
+  commits:
+    - repo: https://github.com/ros-simulation/gazebo_ros_pkgs
+      hash: e9ed0f8e157398621987bd61e2d78683cd945c2b

--- a/confidential/2688e7a/2688e7a.bug
+++ b/confidential/2688e7a/2688e7a.bug
@@ -33,8 +33,7 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repository: CONFIDENTIAL
-  hash: null
+  commits: confidential
   pull-request: null
   license: ['closed source']
   fix-in: ['CONFIDENTIAL']

--- a/confidential/332f09f/332f09f.bug
+++ b/confidential/332f09f/332f09f.bug
@@ -35,8 +35,7 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repository: CONFIDENTIAL
-  hash: null
+  commits: confidential
   pull-request: null
   license: ['closed source']
   fix-in: ['CONFIDENTIAL']

--- a/confidential/3c7cc54/3c7cc54.bug
+++ b/confidential/3c7cc54/3c7cc54.bug
@@ -34,8 +34,7 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repository: CONFIDENTIAL
-  hash: null
+  commits: confidential
   pull-request: null
   license: ['closed source']
   fix-in: ['CONFIDENTIAL']

--- a/confidential/7b11629/7b11629.bug
+++ b/confidential/7b11629/7b11629.bug
@@ -35,8 +35,7 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repository: CONFIDENTIAL
-  hash: null
+  commits: confidential
   pull-request: null
   license: ['closed source']
   fix-in: ['CONFIDENTIAL']

--- a/confidential/81d0a3c/81d0a3c.bug
+++ b/confidential/81d0a3c/81d0a3c.bug
@@ -32,8 +32,7 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repository: CONFIDENTIAL
-  hash: null
+  commits: confidential
   pull-request: null
   license: ['closed source']
   fix-in: ['CONFIDENTIAL']

--- a/confidential/86cb680/86cb680.bug
+++ b/confidential/86cb680/86cb680.bug
@@ -35,8 +35,7 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repository: CONFIDENTIAL
-  hash: null
+  commits: confidential
   pull-request: null
   license: ['closed source']
   fix-in: ['CONFIDENTIAL']

--- a/confidential/96e2c6c/96e2c6c.bug
+++ b/confidential/96e2c6c/96e2c6c.bug
@@ -39,11 +39,12 @@ bug:
   reproducibility: sometimes
   trace: TBD
 fix:
-  repo: CONFIDENTIAL
-  hash: 96e2c6ce746e187ea4276360909e9a71773c3119
   pull-request: null
   license: ['BSD']
   fix-in: ['trajectory_generation.cpp', 'utils.h']
   languages:
     - C++
   time: 2017-02-09 (16:43)
+  commits:
+    - repo: CONFIDENTIAL
+      hash: 96e2c6ce746e187ea4276360909e9a71773c3119

--- a/confidential/96e2c6c/96e2c6c.bug
+++ b/confidential/96e2c6c/96e2c6c.bug
@@ -39,12 +39,10 @@ bug:
   reproducibility: sometimes
   trace: TBD
 fix:
+  commits: confidential
   pull-request: null
   license: ['BSD']
   fix-in: ['trajectory_generation.cpp', 'utils.h']
   languages:
     - C++
   time: 2017-02-09 (16:43)
-  commits:
-    - repo: CONFIDENTIAL
-      hash: 96e2c6ce746e187ea4276360909e9a71773c3119

--- a/confidential/c5dc9de/c5dc9de.bug
+++ b/confidential/c5dc9de/c5dc9de.bug
@@ -32,8 +32,7 @@ bug:
   reproducibility: sometimes
   trace: null
 fix:
-  repository: CONFIDENTIAL
-  hash: null
+  commits: confidential
   pull-request: null
   license: ['closed source']
   fix-in: ['CONFIDENTIAL']

--- a/confidential/e9e7fd8/e9e7fd8.bug
+++ b/confidential/e9e7fd8/e9e7fd8.bug
@@ -34,8 +34,7 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repository: CONFIDENTIAL
-  hash: null
+  commits: confidential
   pull-request: null
   license: ['closed source']
   fix-in: ['CONFIDENTIAL']

--- a/geometry2/001fca6/001fca6.bug
+++ b/geometry2/001fca6/001fca6.bug
@@ -42,14 +42,15 @@ bug:
   trace: null
   reproduction: null
 fix:
-  repo: https://github.com/ros/geometry2
-  hash: 001fca6f33c108c83da4416db3bf43dfeffbe7dd
   pull-request: https://github.com/ros/geometry2/pull/42
   license: ['BSD']
   fix-in: ['tf2_ros/src/buffer.cpp']
   languages:
     - C++
   time: 2013-11-04T08:27:53Z
+  commits:
+    - repo: https://github.com/ros/geometry2
+      hash: 001fca6f33c108c83da4416db3bf43dfeffbe7dd
 time-machine:
   ros_distro: hydro
   ros_pkgs:

--- a/geometry2/0481047/0481047.bug
+++ b/geometry2/0481047/0481047.bug
@@ -50,8 +50,6 @@ bug:
     Issue 84 has a discussion on how to reproduce it. It is a rather simple
     static linking bug, so it should be possible to reproduce.
 fix:
-  repo: https://github.com/ros/geometry2
-  hash: 04810475f249e3f067701288388b82ff0dd686ba
   pull-request: https://github.com/ros/geometry2/pull/86
   license: ['BSD']
   fix-in:
@@ -60,3 +58,6 @@ fix:
   languages:
     - C++
   time: 2015-03-03 (2015-03-12 2:53 GMT+1)
+  commits:
+    - repo: https://github.com/ros/geometry2
+      hash: 04810475f249e3f067701288388b82ff0dd686ba

--- a/geometry2/0af76d5/0af76d5.bug
+++ b/geometry2/0af76d5/0af76d5.bug
@@ -65,8 +65,7 @@ bug:
     the discussions whether a design flaw is a bug, we decided to reproduce the race,
     but not fix the design.  Thus this bug has no fixing commit.
 fix:
-  repo: https://github.com/ros/geometry2
-  hash: null
+  commits: []
   pull-request: null
   license: []
   fix-in: []

--- a/geometry2/0c3aef3/0c3aef3.bug
+++ b/geometry2/0c3aef3/0c3aef3.bug
@@ -50,8 +50,6 @@ bug:
   trace: null
   reproduction: Install tf2 and try to compile.
 fix:
-  repo: https://github.com/ros/geometry2
-  hash: 0c3aef30b7a436b2df553ff08b9a060c94fa3e32
   pull-request: https://github.com/ros/geometry2/pull/170
   license: ["BSD"]
   fix-in:
@@ -59,3 +57,6 @@ fix:
   languages:
     - Package XML
   time: null
+  commits:
+    - repo: https://github.com/ros/geometry2
+      hash: 0c3aef30b7a436b2df553ff08b9a060c94fa3e32

--- a/geometry2/12605ab/12605ab.bug
+++ b/geometry2/12605ab/12605ab.bug
@@ -40,11 +40,12 @@ bug:
     fixed: TODO
     rosdistro: a7fd093f6922394309c317d519ec42d469258ea6
 fix:
-  repo: https://github.com/ros/geometry2
-  hash: 12605ab6b8024395c014e76ecc9b75d853c5c631
   pull-request: https://github.com/ros/geometry2/pull/85
   license: ['BSD']
   fix-in: ['tf2_ros/src/buffer.cpp']
   languages:
     - C++
   time: March 12, 2015, 2:33 AM GMT+1
+  commits:
+    - repo: https://github.com/ros/geometry2
+      hash: 12605ab6b8024395c014e76ecc9b75d853c5c631

--- a/geometry2/15b2e3c/15b2e3c.bug
+++ b/geometry2/15b2e3c/15b2e3c.bug
@@ -35,8 +35,6 @@ bug:
   reproducibility: null
   trace: null
 fix:
-  repo: https://github.com/ros/geometry2
-  hash: https://github.com/ros/geometry2/commit/15b2e3c52152ee4fc19c55ec76f049e990c05809
   pull-request: https://github.com/ros/geometry2/pull/10
   license: ['BSD']
   fix-in:
@@ -45,3 +43,6 @@ fix:
   languages:
     - C++
   time: Jul 10, 2013, 8:48 AM GMT+2
+  commits:
+    - repo: https://github.com/ros/geometry2
+      hash: https://github.com/ros/geometry2/commit/15b2e3c52152ee4fc19c55ec76f049e990c05809

--- a/geometry2/164cfa3/164cfa3.bug
+++ b/geometry2/164cfa3/164cfa3.bug
@@ -60,8 +60,6 @@ bug:
   trace: null
   reproduction: null
 fix:
-  repo: https://github.com/ros/geometry2
-  hash: 164cfa3ef1aad2d11b35894275730fe126e35d3e
   pull-request: https://github.com/ros/geometry2/pull/62
   license: ['BSD']
   fix-in:
@@ -69,3 +67,6 @@ fix:
   languages:
     - C++
   time: 2014-05-12 (21:11 GMT+1)
+  commits:
+    - repo: https://github.com/ros/geometry2
+      hash: 164cfa3ef1aad2d11b35894275730fe126e35d3e

--- a/geometry2/1b44c4d/1b44c4d.bug
+++ b/geometry2/1b44c4d/1b44c4d.bug
@@ -45,8 +45,6 @@ bug:
     buggy 'tf2_eigen.h' file. The compilation will fail during the linking
     phase due to repeated definition of 'tf2::doTransform'.
 fix:
-  repo: https://github.com/mavlink/mavro://github.com/ros/geometry2
-  hash: 1b44c4dced86f11c5b24a4cfadbfd1f21673ac3a
   pull-request: https://github.com/ros/geometry2/pull/200
   license: ['BSD']
   fix-in:
@@ -54,6 +52,9 @@ fix:
   languages:
     - C++
   time: 2017-01-24 11:24PM UTC
+  commits:
+    - repo: https://github.com/mavlink/mavro://github.com/ros/geometry2
+      hash: 1b44c4dced86f11c5b24a4cfadbfd1f21673ac3a
 time-machine:
   ros_distro: indigo
   ros_pkgs:

--- a/geometry2/1b5fa94/1b5fa94.bug
+++ b/geometry2/1b5fa94/1b5fa94.bug
@@ -51,8 +51,6 @@ bug:
     Reproduction would require a long run (perhaps could be faked/accelerated
     by using the buggy function in a loop multiple times.)
 fix:
-  repo: https://github.com/ros/geometry2
-  hash: 1b5fa94cbca8dd5161f29c1697bf71449d14e041
   pull-request: https://github.com/ros/geometry2/pull/251
   license: ['BSD']
   fix-in:
@@ -60,6 +58,9 @@ fix:
   languages:
     - C++
   time: 2017-07-12 5:20PM UTC
+  commits:
+    - repo: https://github.com/ros/geometry2
+      hash: 1b5fa94cbca8dd5161f29c1697bf71449d14e041
 time-machine:
   ros_distro: indigo
   ros_pkgs:

--- a/geometry2/2153716/2153716.bug
+++ b/geometry2/2153716/2153716.bug
@@ -46,8 +46,6 @@ bug:
     would explain why these changes were bundled together.
   trace: N/A
 fix:
-  repo: https://github.com/ros/geometry2
-  hash: 2153716e32d0c12c24f8f80334de1a37d7a3665f
   pull-request: https://github.com/ros/geometry2/pull/158
   license: ['BSD']
   fix-in:
@@ -55,6 +53,9 @@ fix:
   languages:
     - C++
   time: 2016-03-04 4:00 GMT+1
+  commits:
+    - repo: https://github.com/ros/geometry2
+      hash: 2153716e32d0c12c24f8f80334de1a37d7a3665f
 time-machine:
   ros_distro: null
   ros_pkgs: null

--- a/geometry2/245b02b/245b02b.bug
+++ b/geometry2/245b02b/245b02b.bug
@@ -37,8 +37,6 @@ bug:
   trace: null
   reproduction: null
 fix:
-  repo: https://github.com/ros/geometry2
-  hash: 245b02b982981fc80dbea9f50e774e7de6f3c88b
   pull-request: https://github.com/ros/geometry2/pull/101
   license: ['BSD']
   fix-in:
@@ -46,3 +44,6 @@ fix:
   languages:
     - C++
   time: 2015-04-21 (21:42 GMT+1)
+  commits:
+    - repo: https://github.com/ros/geometry2
+      hash: 245b02b982981fc80dbea9f50e774e7de6f3c88b

--- a/geometry2/3ec0485/3ec0485.bug
+++ b/geometry2/3ec0485/3ec0485.bug
@@ -47,8 +47,6 @@ bug:
     triggerred.
   trace: N/A
 fix:
-  repo: https://github.com/ros/geometry2
-  hash: 3ec048516fd47b533d9a40cae97482f5caefbb2f
   pull-request: https://github.com/ros/geometry2/pull/107
   license:
     - BSD
@@ -57,6 +55,9 @@ fix:
   languages:
     - C++
   time: 2015-05-10 21:11 GMT+2
+  commits:
+    - repo: https://github.com/ros/geometry2
+      hash: 3ec048516fd47b533d9a40cae97482f5caefbb2f
 time-machine:
   ros_distro: indigo
   ros_pkgs:

--- a/geometry2/42267be/42267be.bug
+++ b/geometry2/42267be/42267be.bug
@@ -35,8 +35,6 @@ bug:
   trace: null
   reproduction: null
 fix:
-  repo: https://github.com/ros/geometry2
-  hash: 42267be5891035ad65f48e44d5484f91d9702051
   pull-request: https://github.com/ros/geometry2/pull/49
   license: ['BSD']
   fix-in:
@@ -44,3 +42,6 @@ fix:
   languages:
     - CMake
   time: 2013-12-26 (22:46 GMT+1)
+  commits:
+    - repo: https://github.com/ros/geometry2
+      hash: 42267be5891035ad65f48e44d5484f91d9702051

--- a/geometry2/439e235/439e235.bug
+++ b/geometry2/439e235/439e235.bug
@@ -37,8 +37,6 @@ bug:
     A test case should be fairly easy to create by comparing the branching
     before and after the fix.
 fix:
-  repo: https://github.com/ros/geometry2
-  hash: 439e2350ca9b2f0581a3631f0929acc2021db73e
   pull-request: https://github.com/ros/geometry2/pull/187
   license: ['BSD']
   fix-in:
@@ -46,3 +44,6 @@ fix:
   languages:
     - C++
   time: Sep 8, 2016, 10:34 PM GMT+2
+  commits:
+    - repo: https://github.com/ros/geometry2
+      hash: 439e2350ca9b2f0581a3631f0929acc2021db73e

--- a/geometry2/4c160d3/4c160d3.bug
+++ b/geometry2/4c160d3/4c160d3.bug
@@ -29,8 +29,6 @@ bug:
   trace: N/A
   reproduction: null
 fix:
-  repo: https://github.com/ros/geometry2
-  hash: 4c160d3f1bde818fa201ba2c78e25a3e7d9b7cf6
   pull-request: null
   license: ['BSD']
   fix-in:
@@ -38,3 +36,6 @@ fix:
   languages:
     - CMake
   time: 2014-12-16 (10:01am GMT+1)
+  commits:
+    - repo: https://github.com/ros/geometry2
+      hash: 4c160d3f1bde818fa201ba2c78e25a3e7d9b7cf6

--- a/geometry2/561d66b/561d66b.bug
+++ b/geometry2/561d66b/561d66b.bug
@@ -45,8 +45,6 @@ bug:
     available, perhaps just needs to be simplified.
   trace: N/A
 fix:
-  repo: https://github.com/ros/geometry2
-  hash: 561d66b106dec85246161e0b646874bd32812726
   pull-request: https://github.com/ros/geometry2/pull/119
   license: ['BSD']
   fix-in:
@@ -55,6 +53,9 @@ fix:
   languages:
     - Python
   time: 2015-11-16 6:45 GMT+1
+  commits:
+    - repo: https://github.com/ros/geometry2
+      hash: 561d66b106dec85246161e0b646874bd32812726
 time-machine:
   ros_distro: null
   ros_pkgs: null

--- a/geometry2/566092b/566092b.bug
+++ b/geometry2/566092b/566092b.bug
@@ -33,11 +33,12 @@ bug:
     Two replication programs are included that demonstrate the issue; They are
     accessible from the pull request page.
 fix:
-  repo: https://github.com/ros/geometry2
-  hash: 566092b42e3c42b4745294124762f8d7e5176716
   pull-request: https://github.com/ros/geometry2/pull/333
   license: ['BSD']
   fix-in: ['tf2_ros/src/tf2_ros/buffer_client.py']
   languages:
     - Python
   time: Oct 11, 2018, 2:51 AM GMT+2
+  commits:
+    - repo: https://github.com/ros/geometry2
+      hash: 566092b42e3c42b4745294124762f8d7e5176716

--- a/geometry2/589c973/589c973.bug
+++ b/geometry2/589c973/589c973.bug
@@ -39,14 +39,15 @@ bug:
       datetime used for 'time-machine.datetime' is the creation date of the
       PR, as there is no issue for this bug.
 fix:
-  repo: https://github.com/ros/geometry2
-  hash: 589c973ed4250f29b45310e931d5fd4e875aaa33
   pull-request: https://github.com/ros/geometry2/pull/47
   license: ['BSD']
   fix-in: ['tf2/include/tf2/LinearMath/Vector3.h']
   languages:
     - C++
   time: 2013-11-27T17:21:05Z
+  commits:
+    - repo: https://github.com/ros/geometry2
+      hash: 589c973ed4250f29b45310e931d5fd4e875aaa33
 time-machine:
   ros_distro: hydro
   ros_pkgs:

--- a/geometry2/5ad7341/5ad7341.bug
+++ b/geometry2/5ad7341/5ad7341.bug
@@ -41,8 +41,6 @@ bug:
   reproduction: null
 
 fix:
-  repo: https://github.com/ros/geometry2
-  hash: 5ad734114253f6e8da71f47bdf4033e908349b53
   pull-request: https://github.com/ros/geometry2/pull/100
   license: ['BSD']
   fix-in:
@@ -51,3 +49,6 @@ fix:
   languages:
     - C++
   time: 2015-04-21 (21:43 GMT+2)
+  commits:
+    - repo: https://github.com/ros/geometry2
+      hash: 5ad734114253f6e8da71f47bdf4033e908349b53

--- a/geometry2/6c13c78/6c13c78.bug
+++ b/geometry2/6c13c78/6c13c78.bug
@@ -39,8 +39,6 @@ bug:
     allFramesAsYAML and insert an assertion just before line 1337 (see also
     whether it crashes immediately after )
 fix:
-  repo: https://github.com/ros/geometry2
-  hash: 6c13c78a9fd4a9220867f8433243deb00a8d7eb6
   pull-request: https://github.com/ros/geometry2/pull/25
   license: ['BSD']
   fix-in:
@@ -48,6 +46,9 @@ fix:
   languages:
     - C++
   time: Aug 29, 2013, 1:12 AM GMT+2
+  commits:
+    - repo: https://github.com/ros/geometry2
+      hash: 6c13c78a9fd4a9220867f8433243deb00a8d7eb6
 time-machine:
   ros_distro: hydro
   ros_pkgs:

--- a/geometry2/7284788/7284788.bug
+++ b/geometry2/7284788/7284788.bug
@@ -55,16 +55,15 @@ bug:
     Use the test case linked under links above, or if we want a more narrow test case,
     use the trave above (from the first ROS answers links in the links above).
 fix:
-  repo: https://github.com/ros/geometry2
-  hash: 7284788fc1646c6c6afb42bd0e50969387b4cf34
-  # there is no pull request. Fix appears to have been pushed to the
-  # repository directly by tfoote
   pull-request: null
   license: ['BSD']
   fix-in: ['tf2_ros/src/buffer.cpp']
   languages:
     - C++
   time: 2015-04-22T18:16:30Z
+  commits:
+    - repo: https://github.com/ros/geometry2
+      hash: 7284788fc1646c6c6afb42bd0e50969387b4cf34
 time-machine:
   ros_distro: indigo
   ros_pkgs:

--- a/geometry2/729a653/729a653.bug
+++ b/geometry2/729a653/729a653.bug
@@ -42,8 +42,6 @@ bug:
     commit (might require  inserting an assertion to cause  a crash or
     using a sanitizer)
 fix:
-  repo: https://github.com/ros/geometry2
-  hash: 729a6531929203720f4a518ac9e79321fe3c5537
   pull-request: null
   license: ['BSD']
   fix-in:
@@ -51,3 +49,6 @@ fix:
   languages:
     - C++
   time: 2015-04-16 (23:36 GMT+1)
+  commits:
+    - repo: https://github.com/ros/geometry2
+      hash: 729a6531929203720f4a518ac9e79321fe3c5537

--- a/geometry2/74f0c66/74f0c66.bug
+++ b/geometry2/74f0c66/74f0c66.bug
@@ -43,10 +43,11 @@ bug:
   trace: >
     There is a trace reported in the pull request, involving two threads.
 fix:
-  repo: https://github.com/ros/geometry2
-  hash: 74f0c667995b5baadf967349635a5396d7977518
   pull-request: https://github.com/ros/geometry2/pull/144
   license: ['BSD']
   fix-in: ['tf2/src/buffer_core.cpp', 'tf2_ros/include/tf2_ros/message_filter.h']
   languages: ['C++']
   time: 2017-07-13 (00:37)
+  commits:
+    - repo: https://github.com/ros/geometry2
+      hash: 74f0c667995b5baadf967349635a5396d7977518

--- a/geometry2/7677ca7/7677ca7.bug
+++ b/geometry2/7677ca7/7677ca7.bug
@@ -38,11 +38,12 @@ bug:
     rosdistor: null
     note: A compilation with gcc 4.9 should expose the problem.
 fix:
-  repo: https://github.com/ros/geometry2
-  hash: 7677ca7b72781e9482118c9709d838df671a82c0
   pull-request: https://github.com/ros/geometry2/pull/99
   license: ['BSD']
   fix-in: ['tf2_ros/include/tf2_ros/message_filter.h']
   languages:
     - C++
   time: 2015-04-17 12:10 AM GMT+2
+  commits:
+    - repo: https://github.com/ros/geometry2
+      hash: 7677ca7b72781e9482118c9709d838df671a82c0

--- a/geometry2/860b866/860b866.bug
+++ b/geometry2/860b866/860b866.bug
@@ -45,8 +45,6 @@ bug:
     report (exposing the problem).
   trace: N/A
 fix:
-  repo: https://github.com/ros/geometry2
-  hash: 860b8667a9a880b8831e42cb260029a384c99a9a
   pull-request: https://github.com/ros/geometry2/pull/128
   license: ['BSD']
   fix-in:
@@ -54,6 +52,9 @@ fix:
   languages:
     - Python
   time: 2015-12-10 12:09 GMT+1
+  commits:
+    - repo: https://github.com/ros/geometry2
+      hash: 860b8667a9a880b8831e42cb260029a384c99a9a
 time-machine:
   ros_distro: null
   ros_pkgs: null

--- a/geometry2/932c6ca/932c6ca.bug
+++ b/geometry2/932c6ca/932c6ca.bug
@@ -33,8 +33,6 @@ bug:
   trace: null
   reproduction: null
 fix:
-  repo: https://github.com/ros/geometry2
-  hash: 932c6cafd2b7959133fb32303e8c27cca3ff9e33
   pull-request: https://github.com/ros/geometry2/pull/51
   license: ['BSD']
   fix-in:
@@ -43,6 +41,9 @@ fix:
   languages:
     - C++
   time: 2014-01-29T17:46:25Z
+  commits:
+    - repo: https://github.com/ros/geometry2
+      hash: 932c6cafd2b7959133fb32303e8c27cca3ff9e33
 time-machine:
   ros_distro: hydro
   ros_pkgs:

--- a/geometry2/93ea333/93ea333.bug
+++ b/geometry2/93ea333/93ea333.bug
@@ -37,11 +37,12 @@ bug:
   reproduction: >
     Rerun the clang static checker or find the comparable gcc flag.
 fix:
-  repo: https://github.com/ros/geometry2
-  hash: 93ea33319d60d4787afa63d50fa824c3bacc1921
   pull-request: https://github.com/ros/geometry2/pull/81
   license: ['BSD']
   fix-in: ['tf2/include/tf2/LinearMath/Vector3.h']
   languages:
     - C++
   time: 2015-03-03 (09:36 AM GMT+1)
+  commits:
+    - repo: https://github.com/ros/geometry2
+      hash: 93ea33319d60d4787afa63d50fa824c3bacc1921

--- a/geometry2/a2f8eea/a2f8eea.bug
+++ b/geometry2/a2f8eea/a2f8eea.bug
@@ -51,14 +51,15 @@ bug:
       The ROS distro is assumed to be Hydro, as the fix was released as
       part of version 0.4.10, while 0.5.x is the minor used for Indigo.
 fix:
-  repo: https://github.com/ros/geometry2
-  hash: a2f8eea04f95c9abb0e4d7557d796e84fb13a32a
   pull-request: null
   license: ['BSD']
   fix-in: ['tf2_py/src/tf2_py.cpp']
   languages:
     - Python
   time: 2013-12-26T22:51:58Z
+  commits:
+    - repo: https://github.com/ros/geometry2
+      hash: a2f8eea04f95c9abb0e4d7557d796e84fb13a32a
 time-machine:
   ros_distro: hydro
   ros_pkgs:

--- a/geometry2/a723ecb/a723ecb.bug
+++ b/geometry2/a723ecb/a723ecb.bug
@@ -32,10 +32,11 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/ros/geometry2
-  hash: a723ecb68f72d52e538f9e9bdbca3e66f7a69444
   pull-request: null
   license: ['BSD']
   fix-in: ['tf2/CMakeLists.txt']
   languages: ['CMake']
   time: Feb 15, 2013, 12:37 GMT +1
+  commits:
+    - repo: https://github.com/ros/geometry2
+      hash: a723ecb68f72d52e538f9e9bdbca3e66f7a69444

--- a/geometry2/b206807/b206807.bug
+++ b/geometry2/b206807/b206807.bug
@@ -45,8 +45,6 @@ bug:
     above is mostly empty.  This should be revised if anybody ever tries to
     reproduce the bug."
 fix:
-  repo: https://github.com/ros/geometry2
-  hash: b2068070b460fdc0ffc62e707d9085fb26320080
   pull-request: https://github.com/ros/geometry2/pull/176
   license: ["BSD"]
   fix-in:
@@ -54,3 +52,6 @@ fix:
   languages:
     - C++
   time: 2016-05-13 22:27 GMT+2
+  commits:
+    - repo: https://github.com/ros/geometry2
+      hash: b2068070b460fdc0ffc62e707d9085fb26320080

--- a/geometry2/b4dc23c/b4dc23c.bug
+++ b/geometry2/b4dc23c/b4dc23c.bug
@@ -63,14 +63,15 @@ bug:
     change the file, and the fixing commit would either not pass the test, or
     would not apply).
 fix:
-  repo: https://github.com/ros/geometry2
-  hash: b4dc23c54ba06a846c64215a2d8f944c5a1bd036
   pull-request: https://github.com/ros/geometry2/pull/167
   license: ['BSD']
   fix-in: ['tf2_ros/src/static_transform_broadcaster_program.cpp']
   languages:
     - C++
   time: 2016-04-02 (08:29)
+  commits:
+    - repo: https://github.com/ros/geometry2
+      hash: b4dc23c54ba06a846c64215a2d8f944c5a1bd036
 time-machine:
   ros_distro: indigo
   ros_pkgs:

--- a/geometry2/c81fa72/c81fa72.bug
+++ b/geometry2/c81fa72/c81fa72.bug
@@ -31,14 +31,15 @@ bug:
   trace: >
     FIXME: there is a test case added in the fixing commit.
 fix:
-  repo: https://github.com/ros/geometry2
-  hash: c81fa7213ec2ca6512c8015b13a5bbade2b690f7
   pull-request: https://github.com/ros/geometry2/pull/29
   license: ['BSD']
   fix-in: ['tf2_ros/src/static_transform_broadcaster.cpp']
   languages:
     - C++
   time: Oct 15, 2013, 3:04 AM GMT+2
+  commits:
+    - repo: https://github.com/ros/geometry2
+      hash: c81fa7213ec2ca6512c8015b13a5bbade2b690f7
 time-machine:
   ros_distro: hydro
   ros_pkgs:

--- a/geometry2/cec6208/cec6208.bug
+++ b/geometry2/cec6208/cec6208.bug
@@ -55,8 +55,6 @@ bug:
   reproduction: null
 
 fix:
-  repo: https://github.com/ros/geometry2
-  hash: cec62083fa3e54cf210ce8b5ea87b4c0ed60f64b
   pull-request: https://github.com/ros/geometry2/pull/58
   license: ['BSD']
   fix-in:
@@ -64,3 +62,6 @@ fix:
   languages:
     - Python
   time: 2014-03-10 (21:31 GMT+1)
+  commits:
+    - repo: https://github.com/ros/geometry2
+      hash: cec62083fa3e54cf210ce8b5ea87b4c0ed60f64b

--- a/geometry2/d12b890/d12b890.bug
+++ b/geometry2/d12b890/d12b890.bug
@@ -49,11 +49,12 @@ bug:
     It might be hard to write a test, as the objects are most easily created in
     Python, but the error happens in C++ and is not propagated to python
 fix:
-  repo: https://github.com/ros/geometry2
-  hash: d12b8906c8686dc1b980c489a3e4b83d78d6a488
   pull-request: null
   license: ["BSD"]
   fix-in: ["tf2_py/src/tf2_py.cpp"]
   languages:
     - C++
   time: 2017-01-05 20:03 GMT+1
+  commits:
+    - repo: https://github.com/ros/geometry2
+      hash: d12b8906c8686dc1b980c489a3e4b83d78d6a488

--- a/geometry2/d50d51b/d50d51b.bug
+++ b/geometry2/d50d51b/d50d51b.bug
@@ -34,8 +34,6 @@ bug:
   trace: null
   reproduction: null
 fix:
-  repo: https://github.com/ros/geometry2
-  hash: d50d51bced9c851eeb8932d3be0a25df03909bac
   pull-request: https://github.com/ros/geometry2/pull/77
   license: ['BSD']
   fix-in:
@@ -43,3 +41,6 @@ fix:
   languages:
     - C++
   time: 2015-03-03 (9:51 GMT+1)
+  commits:
+    - repo: https://github.com/ros/geometry2
+      hash: d50d51bced9c851eeb8932d3be0a25df03909bac

--- a/geometry2/da141a5/da141a5.bug
+++ b/geometry2/da141a5/da141a5.bug
@@ -48,8 +48,6 @@ bug:
     request 106.
   trace: N/A
 fix:
-  repo: https://github.com/ros/geometry2
-  hash: da141a52c551d482fdd9f0e24a0011050c1307e0
   pull-request: https://github.com/ros/geometry2/pull/109
   license: ['BSD']
   fix-in:
@@ -57,6 +55,9 @@ fix:
   languages:
     - C++
   time: 2015-05-11 18:23 GMT+2
+  commits:
+    - repo: https://github.com/ros/geometry2
+      hash: da141a52c551d482fdd9f0e24a0011050c1307e0
 time-machine:
   ros_distro: null
   ros_pkgs: null

--- a/geometry2/e12e723/e12e723.bug
+++ b/geometry2/e12e723/e12e723.bug
@@ -42,8 +42,6 @@ bug:
       classified as a build failure / problem, the workspace will build
       as only at runtime the missing package will cause actual problems.
 fix:
-  repo: https://github.com/ros/geometry2
-  hash: 1f019166ccedf8ce5151944f5e33302afaf82679
   pull-request: https://github.com/ros/geometry2/pull/150
   license:
     - BSD
@@ -52,6 +50,9 @@ fix:
   languages:
     - Package XML
   time: 2016-03-04 03:30 GMT+1
+  commits:
+    - repo: https://github.com/ros/geometry2
+      hash: 1f019166ccedf8ce5151944f5e33302afaf82679
 time-machine:
   ros_distro: indigo
   ros_pkgs:

--- a/geometry2/e4466f0/e4466f0.bug
+++ b/geometry2/e4466f0/e4466f0.bug
@@ -43,8 +43,6 @@ bug:
     The discussion indicates that one needs to create a frame with a numeric id.
   trace: N/A
 fix:
-  repo: https://github.com/ros/geometry2
-  hash: e4466f0f482dcacf79b9ab9deaa70429e161e3a6
   pull-request: https://github.com/ros/geometry2/pull/133
   license: ['BSD']
   fix-in:
@@ -52,6 +50,9 @@ fix:
   languages:
     - Python
   time: 2015-12-15 11:45 GMT+1
+  commits:
+    - repo: https://github.com/ros/geometry2
+      hash: e4466f0f482dcacf79b9ab9deaa70429e161e3a6
 time-machine:
   ros_distro: null
   ros_pkgs: null

--- a/geometry2/ede2646/ede2646.bug
+++ b/geometry2/ede2646/ede2646.bug
@@ -41,8 +41,6 @@ bug:
   reproduction: >
     The bug report includes a test case. This should be used.
 fix:
-  repo: https://github.com/ros/geometry2
-  hash: ede2646d463c8ae1bbbf2460941df2b07d39824e
   pull-request: https://github.com/ros/geometry2/pull/90
   license: ['BSD']
   fix-in:
@@ -50,3 +48,6 @@ fix:
   languages:
     - Python
   time: 2015-03-20 (19:08 AM GMT+1)
+  commits:
+    - repo: https://github.com/ros/geometry2
+      hash: ede2646d463c8ae1bbbf2460941df2b07d39824e

--- a/geometry2/f19569c/f19569c.bug
+++ b/geometry2/f19569c/f19569c.bug
@@ -53,8 +53,6 @@ bug:
   trace: null
   reproduction: null
 fix:
-  repo: https://github.com/ros/geometry2
-  hash: f19569cf095cdb92ab012a2ffa03c1074bad2c4a
   pull-request: https://github.com/ros/geometry2/pull/76
   license: ['BSD']
   fix-in:
@@ -65,3 +63,6 @@ fix:
   languages:
     - C++
   time: 2015-03-03 (10:03 GMT+1)
+  commits:
+    - repo: https://github.com/ros/geometry2
+      hash: f19569cf095cdb92ab012a2ffa03c1074bad2c4a

--- a/geometry2/f2568f5/f2568f5.bug
+++ b/geometry2/f2568f5/f2568f5.bug
@@ -39,8 +39,6 @@ bug:
     Look into the text of issue 119 (known as 561d66b in robust).
   trace: N/A
 fix:
-  repo: https://github.com/ros/geometry2
-  hash: f2568f597923d0ea4495c18cd828a67f12e05f0a
   pull-request: https://github.com/ros/geometry2/pull/126
   license: ['BSD']
   fix-in:
@@ -48,6 +46,9 @@ fix:
   languages:
     - Package XML
   time: 2015-11-16 8:55 GMT+1
+  commits:
+    - repo: https://github.com/ros/geometry2
+      hash: f2568f597923d0ea4495c18cd828a67f12e05f0a
 time-machine:
   ros_distro: null
   ros_pkgs: null

--- a/geometry2/fc854e0/fc854e0.bug
+++ b/geometry2/fc854e0/fc854e0.bug
@@ -38,14 +38,15 @@ bug:
       datetime used for 'time-machine.datetime' is the creation date of the
       PR, as there is no issue for this bug.
 fix:
-  repo: https://github.com/ros/geometry2
-  hash: fc854e0e7013e9a05c3c4f50eb1375aa0ad26841
   pull-request: https://github.com/ros/geometry2/pull/44
   license: ['BSD']
   fix-in: ['tf2_tools/CMakeLists.txt']
   languages:
     - CMake
   time: 2013-11-06 (08:19 GMT+1)
+  commits:
+    - repo: https://github.com/ros/geometry2
+      hash: fc854e0e7013e9a05c3c4f50eb1375aa0ad26841
 time-machine:
   ros_distro: hydro
   ros_pkgs:

--- a/kobuki/0027b57/0027b57.bug
+++ b/kobuki/0027b57/0027b57.bug
@@ -33,8 +33,11 @@ bug:
   reproducibility: sometimes
   trace: N/A
 fix:
-  repo: https://github.com/yujinrobot/kobuki
-  hash: 0027b57fea017e610baa226b6645a5a1c071f05c | 087aa595f7c93ed7f34c3fb9db5629532bdf972a
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: 0027b57fea017e610baa226b6645a5a1c071f05c
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: 087aa595f7c93ed7f34c3fb9db5629532bdf972a
   pull-request: null
   license: ['BSD']
   fix-in: ['kobuki_ftdi/include/kobuki_ftdi/scanner.hpp', 'kobuki_ftdi/manifest.xml']

--- a/kobuki/03660af/03660af.bug
+++ b/kobuki/03660af/03660af.bug
@@ -30,11 +30,12 @@ bug:
   reproducibility: rare
   trace: null
 fix:
-  repo: https://github.com/yujinrobot/kobuki
-  hash: 03660afb5917366cc6d57567e2f695450fd95feb
   pull-request: null
   license: ['BSD']
   fix-in: ['kobuki_driver/include/kobuki_driver/kobuki.hpp', 'kobuki_driver/src/driver/kobuki.cpp']
   languages:
     - C++
   time: 2012-06-04 (05:58)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: 03660afb5917366cc6d57567e2f695450fd95feb

--- a/kobuki/0416c81/0416c81.bug
+++ b/kobuki/0416c81/0416c81.bug
@@ -32,8 +32,6 @@ bug:
   reproducibility: sometimes
   trace: null
 fix:
-  repo: https://github.com/yujinrobot/kobuki
-  hash: 0416c81e5d08466477c5806443a580a142d0d465
   pull-request: null
   license: ['BSD']
   fix-in:
@@ -43,3 +41,6 @@ fix:
   languages:
     - C++
   time: 2013-05-24 (07:28)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: 0416c81e5d08466477c5806443a580a142d0d465

--- a/kobuki/054c753/054c753.bug
+++ b/kobuki/054c753/054c753.bug
@@ -41,11 +41,12 @@ bug:
   reproducibility: sometimes
   trace: null
 fix:
-  repo: https://github.com/yujinrobot/kobuki
-  hash: 054c753b40b56b20c39051e14bdab71bc50e1ae8
   pull-request: https://github.com/yujinrobot/kobuki/pull/278
   license: ['BSD']
   fix-in: ['kobuki_driver/src/driver/kobuki.cpp']
   languages:
     - C++
   time: 2013-08-01 (07:33)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: 054c753b40b56b20c39051e14bdab71bc50e1ae8

--- a/kobuki/17560e9/17560e9.bug
+++ b/kobuki/17560e9/17560e9.bug
@@ -53,14 +53,15 @@ bug:
     rosinstall file had to be patched manually. Cf. issue
     https://github.com/robust-rosin/robust/issues/63.
 fix:
-  repo: https://github.com/yujinrobot/yujin_ocs
-  hash: 17560e98ef751714a352a5cee403fd3eb53c9fdb
   pull-request: null
   license: ['BSD']
   fix-in: ['yocs_navigator/CMakeLists.txt']
   languages:
     - CMake
   time: 2014-08-25 (02:04)
+  commits:
+    - repo: https://github.com/yujinrobot/yujin_ocs
+      hash: 17560e98ef751714a352a5cee403fd3eb53c9fdb
 time-machine:
   ros_distro: indigo
   ros_pkgs:

--- a/kobuki/1c141a5/1c141a5.bug
+++ b/kobuki/1c141a5/1c141a5.bug
@@ -32,11 +32,12 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/yujinrobot/kobuki
-  hash: 1c141a54fb2c0e2ec453b32f8026d1cd0ffb14d9
   pull-request: null
   license: ['BSD']
   fix-in: ['kobuki_driver/include/kobuki_driver/modules/diff_drive.hpp', 'kobuki_driver/src/driver/diff_drive.cpp']
   languages:
     - C++
   time: 2013-05-07 (06:40)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: 1c141a54fb2c0e2ec453b32f8026d1cd0ffb14d9

--- a/kobuki/27e85fc/27e85fc.bug
+++ b/kobuki/27e85fc/27e85fc.bug
@@ -27,11 +27,12 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/yujinrobot/kobuki_desktop
-  hash: 27e85fc224fc6198b55c5af0d066c7901af8ec0b
   pull-request: null
   license: ['BSD']
   fix-in: ['kobuki_gazebo_plugins/src/gazebo_ros_kobuki.cpp']
   languages:
     - C++
   time: 2013-08-09 (08:14)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki_desktop
+      hash: 27e85fc224fc6198b55c5af0d066c7901af8ec0b

--- a/kobuki/2f647af/2f647af.bug
+++ b/kobuki/2f647af/2f647af.bug
@@ -45,9 +45,13 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/yujinrobot/kobuki
-  hash: 2f647af053c451e4248d7741c542f63511eee45e | a174dbbb9375d22828b0d7f4f41b7265978845c0
-    | 9c4835ad5b2eb3a4945f57076501b7699057ec66
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: 2f647af053c451e4248d7741c542f63511eee45e
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: a174dbbb9375d22828b0d7f4f41b7265978845c0
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: 9c4835ad5b2eb3a4945f57076501b7699057ec66
   pull-request: null
   license: ['BSD']
   fix-in:

--- a/kobuki/35682ec/35682ec.bug
+++ b/kobuki/35682ec/35682ec.bug
@@ -44,8 +44,6 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/yujinrobot/kobuki
-  hash: 35682ec3c3e7177373c66c48228ad58b2eb34aae
   pull-request: null
   license: ['BSD']
   fix-in:
@@ -53,3 +51,6 @@ fix:
   languages:
     - Launch XML
   time: 2013-02-25 (08:34)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: 35682ec3c3e7177373c66c48228ad58b2eb34aae

--- a/kobuki/38bee3a/38bee3a.bug
+++ b/kobuki/38bee3a/38bee3a.bug
@@ -28,11 +28,12 @@ bug:
   reproducibility: sometimes
   trace: null
 fix:
-  repo: https://github.com/yujinrobot/kobuki
-  hash: 38bee3acd7cf36960a4ce2bef821421db27a57f4
   pull-request: null
   license: ['BSD']
   fix-in: ['kobuki_driver/include/kobuki_driver/kobuki.hpp', 'kobuki_driver/src/driver/kobuki.cpp']
   languages:
     - C++
   time: 2012-11-21 (00:38)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: 38bee3acd7cf36960a4ce2bef821421db27a57f4

--- a/kobuki/38dce2a/38dce2a.bug
+++ b/kobuki/38dce2a/38dce2a.bug
@@ -36,11 +36,12 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/yujinrobot/kobuki
-  hash: 38dce2aac9c4a519fbcec4032838a3451662e7b6
   pull-request: null
   license: ['BSD']
   fix-in: ['kobuki_safety_controller/src/nodelet.cpp']
   languages:
     - C++
   time: 2012-12-05 (03:43)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: 38dce2aac9c4a519fbcec4032838a3451662e7b6

--- a/kobuki/3c4c399/3c4c399.bug
+++ b/kobuki/3c4c399/3c4c399.bug
@@ -32,8 +32,6 @@ bug:
   reproducibility: rare
   trace: null
 fix:
-  repo: https://github.com/yujinrobot/kobuki
-  hash: 3c4c399a460b314152722de6b99804e138d68e88
   pull-request: null
   license: ['BSD']
   fix-in:
@@ -43,3 +41,6 @@ fix:
   languages:
     - C++
   time: 2013-08-22 (09:40)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: 3c4c399a460b314152722de6b99804e138d68e88

--- a/kobuki/3c7f92a/3c7f92a.bug
+++ b/kobuki/3c7f92a/3c7f92a.bug
@@ -32,8 +32,6 @@ bug:
     line 54, in redraw data_x, data_y, plot = curve ValueError: too many values to
     unpack
 fix:
-  repo: https://github.com/yujinrobot/kobuki_desktop
-  hash: 3c7f92a2c6a51b4896e669d0da34b4de90a71914
   pull-request: null
   license: ['BSD']
   fix-in:
@@ -48,3 +46,6 @@ fix:
     - Python
     - Other XML
   time: 2013-08-21 (10:23)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki_desktop
+      hash: 3c7f92a2c6a51b4896e669d0da34b4de90a71914

--- a/kobuki/3e88010/3e88010.bug
+++ b/kobuki/3e88010/3e88010.bug
@@ -28,11 +28,12 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/yujinrobot/kobuki
-  hash: 3e88010293c350ffa71f5e8b64ec58ec09a64549
   pull-request: null
   license: ['BSD']
   fix-in: ['kobuki_auto_docking/CMakeLists.txt']
   languages:
     - CMake
   time: 2013-02-25 (04:36)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: 3e88010293c350ffa71f5e8b64ec58ec09a64549

--- a/kobuki/4115400/4115400.bug
+++ b/kobuki/4115400/4115400.bug
@@ -38,8 +38,6 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/yujinrobot/kobuki_desktop
-  hash: 4115400a5a9b88bf65bb97a5d44a9a2a695faa55
   pull-request: https://github.com/yujinrobot/kobuki_desktop/pull/39
   license: ['BSD']
   fix-in:
@@ -47,3 +45,6 @@ fix:
   languages:
     - C++
   time: 2015-03-02 (08:03)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki_desktop
+      hash: 4115400a5a9b88bf65bb97a5d44a9a2a695faa55

--- a/kobuki/45ee84a/45ee84a.bug
+++ b/kobuki/45ee84a/45ee84a.bug
@@ -36,11 +36,12 @@ bug:
     Following the issue at:
     https://github.com/robust-rosin/robust/issues/144
 fix:
-  repo: https://github.com/yujinrobot/kobuki_core
-  hash: 45ee84aa1e920b26f8191763e20c10c5806ead60
   pull-request: null
   license: ['BSD']
   fix-in: ['kobuki_ftdi/CMakeLists.txt']
   languages:
     - CMake
   time: 2015-02-12 (00:18)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki_core
+      hash: 45ee84aa1e920b26f8191763e20c10c5806ead60

--- a/kobuki/493e3f9/493e3f9.bug
+++ b/kobuki/493e3f9/493e3f9.bug
@@ -31,11 +31,12 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/yujinrobot/kobuki
-  hash: 493e3f9c9f65fbf0283571ca92b89a7203e5f287
   pull-request: null
   license: ['BSD']
   fix-in: ['kobuki_description/urdf/kobuki.urdf.xacro']
   languages:
     - URDF
   time: 2013-08-20 (10:22)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: 493e3f9c9f65fbf0283571ca92b89a7203e5f287

--- a/kobuki/496aac8/496aac8.bug
+++ b/kobuki/496aac8/496aac8.bug
@@ -32,8 +32,6 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/yujinrobot/kobuki_desktop
-  hash: 496aac8304f6d3dae568e1559471ed6354fdfe92
   pull-request: null
   license: ['BSD']
   fix-in:
@@ -42,3 +40,6 @@ fix:
   languages:
     - C++
   time: 2013-08-26 (09:18)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki_desktop
+      hash: 496aac8304f6d3dae568e1559471ed6354fdfe92

--- a/kobuki/4ea5ea7/4ea5ea7.bug
+++ b/kobuki/4ea5ea7/4ea5ea7.bug
@@ -29,8 +29,6 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/yujinrobot/kobuki
-  hash: 4ea5ea7ff535323baeada165764b5b8ceb7bfa87
   pull-request: null
   license: ['BSD']
   fix-in:
@@ -43,3 +41,6 @@ fix:
     - RViz
     - Xacro
   time: unfixed
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: 4ea5ea7ff535323baeada165764b5b8ceb7bfa87

--- a/kobuki/55e84a6/55e84a6.bug
+++ b/kobuki/55e84a6/55e84a6.bug
@@ -26,29 +26,41 @@ bug:
   time-reported: 2014-08-08T06:25:24Z
   reproducibility: always
   trace: >
-    PluginManager._load_plugin() could not load plugin "kobuki_qtestsuite/Kobuki Test Suite":
+    PluginManager._load_plugin() could not load plugin "kobuki_qtestsuite/Kobuki Test
+    Suite":
     Traceback (most recent call last):
-      File "/opt/ros/indigo/lib/python2.7/dist-packages/qt_gui/plugin_handler.py", line 98, in load
+      File "/opt/ros/indigo/lib/python2.7/dist-packages/qt_gui/plugin_handler.py",
+    line 98, in load
         self._load()
-      File "/opt/ros/indigo/lib/python2.7/dist-packages/qt_gui/plugin_handler_direct.py", line 54, in _load
+      File "/opt/ros/indigo/lib/python2.7/dist-packages/qt_gui/plugin_handler_direct.py",
+    line 54, in _load
         self._plugin = self._plugin_provider.load(self._instance_id.plugin_id, self._context)
-      File "/opt/ros/indigo/lib/python2.7/dist-packages/qt_gui/composite_plugin_provider.py", line 71, in load
+      File "/opt/ros/indigo/lib/python2.7/dist-packages/qt_gui/composite_plugin_provider.py",
+    line 71, in load
         instance = plugin_provider.load(plugin_id, plugin_context)
-      File "/opt/ros/indigo/lib/python2.7/dist-packages/qt_gui/composite_plugin_provider.py", line 71, in load
+      File "/opt/ros/indigo/lib/python2.7/dist-packages/qt_gui/composite_plugin_provider.py",
+    line 71, in load
         instance = plugin_provider.load(plugin_id, plugin_context)
-      File "/opt/ros/indigo/lib/python2.7/dist-packages/rqt_gui_py/ros_py_plugin_provider.py", line 60, in load
+      File "/opt/ros/indigo/lib/python2.7/dist-packages/rqt_gui_py/ros_py_plugin_provider.py",
+    line 60, in load
         return super(RosPyPluginProvider, self).load(plugin_id, plugin_context)
-      File "/opt/ros/indigo/lib/python2.7/dist-packages/qt_gui/composite_plugin_provider.py", line 71, in load
+      File "/opt/ros/indigo/lib/python2.7/dist-packages/qt_gui/composite_plugin_provider.py",
+    line 71, in load
         instance = plugin_provider.load(plugin_id, plugin_context)
-      File "/opt/ros/indigo/lib/python2.7/dist-packages/rqt_gui/ros_plugin_provider.py", line 94, in load
+      File "/opt/ros/indigo/lib/python2.7/dist-packages/rqt_gui/ros_plugin_provider.py",
+    line 94, in load
         return class_ref(plugin_context)
-      File "/home/jihoonl/research/ros/kobuki/src/kobuki_desktop/kobuki_qtestsuite/src/kobuki_qtestsuite/testsuite.py", line 43, in __init__
+      File "/home/jihoonl/research/ros/kobuki/src/kobuki_desktop/kobuki_qtestsuite/src/kobuki_qtestsuite/testsuite.py",
+    line 43, in __init__
         self._widget.setupUi()
-      File "/home/jihoonl/research/ros/kobuki/src/kobuki_desktop/kobuki_qtestsuite/src/kobuki_qtestsuite/testsuite_widget.py", line 43, in setupUi
+      File "/home/jihoonl/research/ros/kobuki/src/kobuki_desktop/kobuki_qtestsuite/src/kobuki_qtestsuite/testsuite_widget.py",
+    line 43, in setupUi
         self._ui.battery_profile_frame.setupUi(self._ui.configuration_dock.cmd_vel_topic_name())
-      File "/home/jihoonl/research/ros/kobuki/src/kobuki_desktop/kobuki_qtestsuite/src/kobuki_qtestsuite/battery_profile_frame.py", line 51, in setupUi
+      File "/home/jihoonl/research/ros/kobuki/src/kobuki_desktop/kobuki_qtestsuite/src/kobuki_qtestsuite/battery_profile_frame.py",
+    line 51, in setupUi
         self._plot_widget.switch_data_plot_widget(FullSizeDataPlot(self._plot_widget))
-      File "/opt/ros/indigo/lib/python2.7/dist-packages/rqt_plot/plot_widget.py", line 150, in switch_data_plot_widget
+      File "/opt/ros/indigo/lib/python2.7/dist-packages/rqt_plot/plot_widget.py",
+    line 150, in switch_data_plot_widget
         self.data_plot.autoscroll(self.autoscroll_checkbox.isChecked())
     AttributeError: 'FullSizeDataPlot' object has no attribute 'autoscroll'
 fix:

--- a/kobuki/55e84a6/55e84a6.bug
+++ b/kobuki/55e84a6/55e84a6.bug
@@ -64,9 +64,13 @@ bug:
         self.data_plot.autoscroll(self.autoscroll_checkbox.isChecked())
     AttributeError: 'FullSizeDataPlot' object has no attribute 'autoscroll'
 fix:
-  repo: https://github.com/yujinrobot/kobuki_desktop
-  hash: 5ee65b061a4a919b2a32e80087f4cb3e51e924ed | 6df4bd7e92aea5cf3696b20861fca0ed413ece6e
-    | 55e84a61e50d23be20f1d7abb4018a635370bff4
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki_desktop
+      hash: 5ee65b061a4a919b2a32e80087f4cb3e51e924ed
+    - repo: https://github.com/yujinrobot/kobuki_desktop
+      hash: 6df4bd7e92aea5cf3696b20861fca0ed413ece6e
+    - repo: https://github.com/yujinrobot/kobuki_desktop
+      hash: 55e84a61e50d23be20f1d7abb4018a635370bff4
   pull-request: null
   license: ['BSD']
   fix-in:

--- a/kobuki/5a44ead/5a44ead.bug
+++ b/kobuki/5a44ead/5a44ead.bug
@@ -30,11 +30,12 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/yujinrobot/kobuki
-  hash: 5a44eadd3b6ef0f2cb29f057b3e1cdb93205c954
   pull-request: null
   license: ['BSD']
   fix-in: ['kobuki_driver/src/test/initialisation.cpp']
   languages:
     - C++
   time: 2013-05-31 (08:09)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: 5a44eadd3b6ef0f2cb29f057b3e1cdb93205c954

--- a/kobuki/5abe7d4/5abe7d4.bug
+++ b/kobuki/5abe7d4/5abe7d4.bug
@@ -28,8 +28,6 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/yujinrobot/kobuki_desktop
-  hash: 5abe7d4ae9f8fb323d4acb6fe131d87a82efef31
   pull-request: null
   license: ['BSD']
   fix-in:
@@ -38,3 +36,6 @@ fix:
   languages:
     - C++
   time: 2013-10-11 (03:36)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki_desktop
+      hash: 5abe7d4ae9f8fb323d4acb6fe131d87a82efef31

--- a/kobuki/5ee65b0/5ee65b0.bug
+++ b/kobuki/5ee65b0/5ee65b0.bug
@@ -70,11 +70,12 @@ bug:
     Thus, the final solution has to mimic the original code, but stripping
     the GUI-related parts.
 fix:
-  repo: https://github.com/yujinrobot/kobuki_desktop
-  hash: 5ee65b061a4a919b2a32e80087f4cb3e51e924ed
   pull-request: null
   license: ['BSD']
   fix-in: ['kobuki_dashboard/src/kobuki_dashboard/led_widget.py', 'kobuki_dashboard/src/kobuki_dashboard/motor_widget.py']
   languages:
     - Python
   time: 2014-08-08 (11:25)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki_desktop
+      hash: 5ee65b061a4a919b2a32e80087f4cb3e51e924ed

--- a/kobuki/606b8b9/606b8b9.bug
+++ b/kobuki/606b8b9/606b8b9.bug
@@ -29,11 +29,12 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/yujinrobot/kobuki
-  hash: 606b8b9434ce501ff663e9252f5459eb9c50c6af
   pull-request: null
   license: ['BSD']
   fix-in: ['kobuki_ftdi/57-kobuki.rules']
   languages:
     - udev rules
   time: 2013-02-19 (07:15)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: 606b8b9434ce501ff663e9252f5459eb9c50c6af

--- a/kobuki/62a38a9/62a38a9.bug
+++ b/kobuki/62a38a9/62a38a9.bug
@@ -52,11 +52,12 @@ bug:
     Flag     : Attempted to work on an invalid object.
     Detail   : The device is not a valid device for writing.
 fix:
-  repo: https://github.com/yujinrobot/kobuki
-  hash: 62a38a99cdfaf511cff1dd9e03b7bb88516f9033
   pull-request: null
   license: ['BSD']
   fix-in: ['kobuki_driver/include/kobuki_driver/kobuki.hpp', 'kobuki_driver/src/driver/kobuki.cpp']
   languages:
     - C++
   time: 2012-04-14 (14:12)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: 62a38a99cdfaf511cff1dd9e03b7bb88516f9033

--- a/kobuki/6e748c1/6e748c1.bug
+++ b/kobuki/6e748c1/6e748c1.bug
@@ -45,11 +45,12 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/yujinrobot/kobuki
-  hash: 6e748c1df1024847de91d899506ae872759d1094
   pull-request: null
   license: ['BSD']
   fix-in: ['kobuki_node/src/nodelet/kobuki_nodelet.cpp']
   languages:
     - C++
   time: 2014-04-21 (07:38)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: 6e748c1df1024847de91d899506ae872759d1094

--- a/kobuki/8163705/8163705.bug
+++ b/kobuki/8163705/8163705.bug
@@ -29,11 +29,12 @@ bug:
   reproducibility: sometimes
   trace: null
 fix:
-  repo: https://github.com/yujinrobot/kobuki
-  hash: 816370545bf199f03e6259443861226b9701775e
   pull-request: null
   license: ['BSD']
   fix-in: ['kobuki_node/src/library/kobuki_ros.cpp']
   languages:
     - C++
   time: 2012-12-01 (07:36)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: 816370545bf199f03e6259443861226b9701775e

--- a/kobuki/841720a/841720a.bug
+++ b/kobuki/841720a/841720a.bug
@@ -38,8 +38,6 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/yujinrobot/kobuki
-  hash: 841720ab97e442a11ae30b7abdbef07150e56c97
   pull-request: null
   license: ['BSD']
   fix-in:
@@ -53,3 +51,6 @@ fix:
     - C++
     - ROS Message
   time: 2012-06-25 (13:14)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: 841720ab97e442a11ae30b7abdbef07150e56c97

--- a/kobuki/8a729db/8a729db.bug
+++ b/kobuki/8a729db/8a729db.bug
@@ -48,8 +48,6 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/yujinrobot/kobuki
-  hash: 8a729db54ee9a8b43f4634ab8052ddaa24d517fd
   pull-request: null
   license: ['BSD']
   fix-in:
@@ -57,3 +55,6 @@ fix:
   languages:
     - Param YAML
   time: 2014-08-26 (06:54)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: 8a729db54ee9a8b43f4634ab8052ddaa24d517fd

--- a/kobuki/8c30446/8c30446.bug
+++ b/kobuki/8c30446/8c30446.bug
@@ -58,8 +58,6 @@ bug:
     version no longer uses a file from another package (in this case,
     `turtlebot_bringup`).
 fix:
-  repo: https://github.com/yujinrobot/kobuki
-  hash: 8c30446d18bad63da0f58a1f666c2e7e209d917d
   pull-request: null
   license: ['BSD']
   fix-in:
@@ -67,3 +65,6 @@ fix:
   languages:
     - Launch XML
   time: 2014-08-11 (06:11)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: 8c30446d18bad63da0f58a1f666c2e7e209d917d

--- a/kobuki/9397c6b/9397c6b.bug
+++ b/kobuki/9397c6b/9397c6b.bug
@@ -34,8 +34,6 @@ bug:
   reproducibility: sometimes
   trace: null
 fix:
-  repo: https://github.com/stonier/ecl_core
-  hash: 9397c6b872cba3e894171507ef23f366fc968f3e
   pull-request: null
   license: ['BSD']
   fix-in:
@@ -47,3 +45,6 @@ fix:
   languages:
     - C++
   time: 2012-12-03 (03:20)
+  commits:
+    - repo: https://github.com/stonier/ecl_core
+      hash: 9397c6b872cba3e894171507ef23f366fc968f3e

--- a/kobuki/95b24e8/95b24e8.bug
+++ b/kobuki/95b24e8/95b24e8.bug
@@ -28,11 +28,12 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/yujinrobot/kobuki
-  hash: 95b24e8218ea593cf820478e0829adc92fff7457
   pull-request: null
   license: ['BSD']
   fix-in: ['kobuki_driver/src/driver/kobuki.cpp']
   languages:
     - C++
   time: 2012-04-09 (06:13)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: 95b24e8218ea593cf820478e0829adc92fff7457

--- a/kobuki/9682b9a/9682b9a.bug
+++ b/kobuki/9682b9a/9682b9a.bug
@@ -65,8 +65,11 @@ bug:
     UserWarning: icon "../src/kobuki_qtestsuite/resources/images/kobuki_icon.png"
     not found
 fix:
-  repo: https://github.com/ros-visualization/rqt | https://github.com/ros-visualization/qt_gui_core
-  hash: 9682b9af78eecd368004fe7596e341eb84abc719 | ffae1f756dbf23194a2628922939d9633df947f6
+  commits:
+    - repo: https://github.com/ros-visualization/rqt
+      hash: 9682b9af78eecd368004fe7596e341eb84abc719
+    - repo: https://github.com/ros-visualization/qt_gui_core
+      hash: ffae1f756dbf23194a2628922939d9633df947f6
   pull-request: null
   license: ['BSD']
   fix-in:

--- a/kobuki/9682b9a/9682b9a.bug
+++ b/kobuki/9682b9a/9682b9a.bug
@@ -41,21 +41,29 @@ bug:
     Traceback (most recent call last):
       File "/opt/ros/groovy/lib/rqt_plot/rqt_plot", line 10, in <module>
         sys.exit(main.main(standalone=plugin, plugin_argument_provider=Plot.add_arguments))
-      File "/opt/ros/groovy/lib/python2.7/dist-packages/rqt_gui/main.py", line 57, in main
+      File "/opt/ros/groovy/lib/python2.7/dist-packages/rqt_gui/main.py", line 57,
+    in main
         return super(Main, self).main(argv, standalone=standalone, plugin_argument_provider=plugin_argument_provider)
-      File "/opt/ros/groovy/lib/python2.7/dist-packages/qt_gui/main.py", line 468, in main
+      File "/opt/ros/groovy/lib/python2.7/dist-packages/qt_gui/main.py", line 468,
+    in main
         plugins = plugin_manager.find_plugins_by_name(plugin)
-      File "/opt/ros/groovy/lib/python2.7/dist-packages/qt_gui/plugin_manager.py", line 118, in find_plugins_by_name
+      File "/opt/ros/groovy/lib/python2.7/dist-packages/qt_gui/plugin_manager.py",
+    line 118, in find_plugins_by_name
         for plugin_id, plugin_full_name in self.get_plugins().items():
-      File "/opt/ros/groovy/lib/python2.7/dist-packages/qt_gui/plugin_manager.py", line 124, in get_plugins
+      File "/opt/ros/groovy/lib/python2.7/dist-packages/qt_gui/plugin_manager.py",
+    line 124, in get_plugins
         self.discover()
-      File "/opt/ros/groovy/lib/python2.7/dist-packages/qt_gui/plugin_manager.py", line 108, in discover
+      File "/opt/ros/groovy/lib/python2.7/dist-packages/qt_gui/plugin_manager.py",
+    line 108, in discover
         self._plugin_menu.add_plugin(plugin_descriptor)
-      File "/opt/ros/groovy/lib/python2.7/dist-packages/qt_gui/plugin_menu.py", line 79, in add_plugin
+      File "/opt/ros/groovy/lib/python2.7/dist-packages/qt_gui/plugin_menu.py", line
+    79, in add_plugin
         self._enrich_action(action, action_attributes, base_path)
-      File "/opt/ros/groovy/lib/python2.7/dist-packages/qt_gui/plugin_menu.py", line 130, in _enrich_action
+      File "/opt/ros/groovy/lib/python2.7/dist-packages/qt_gui/plugin_menu.py", line
+    130, in _enrich_action
         raise UserWarning('icon "%s" not found' % str(path))
-    UserWarning: icon "../src/kobuki_qtestsuite/resources/images/kobuki_icon.png" not found
+    UserWarning: icon "../src/kobuki_qtestsuite/resources/images/kobuki_icon.png"
+    not found
 fix:
   repo: https://github.com/ros-visualization/rqt | https://github.com/ros-visualization/qt_gui_core
   hash: 9682b9af78eecd368004fe7596e341eb84abc719 | ffae1f756dbf23194a2628922939d9633df947f6

--- a/kobuki/9c8abeb/9c8abeb.bug
+++ b/kobuki/9c8abeb/9c8abeb.bug
@@ -42,11 +42,12 @@ bug:
     This package is not distributed in the standard Ubuntu repositories
     for Ubuntu Precise, the distribution used to reproduce this bug.
 fix:
-  repo: https://github.com/yujinrobot/kobuki_desktop
-  hash: 9c8abeb81acb2d18a086ac18cd88a8cf6dd9e200
   pull-request: https://github.com/yujinrobot/kobuki_desktop/pull/26
   license: ['BSD']
   fix-in: ['kobuki_gazebo_plugins/src/gazebo_ros_kobuki.cpp']
   languages:
     - C++
   time: 2014-03-02 (15:03)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki_desktop
+      hash: 9c8abeb81acb2d18a086ac18cd88a8cf6dd9e200

--- a/kobuki/9de9690/9de9690.bug
+++ b/kobuki/9de9690/9de9690.bug
@@ -38,8 +38,6 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/yujinrobot/kobuki
-  hash: 9de969082a80944fa779a17a570877901289e31f
   pull-request: null
   license: ['BSD']
   fix-in:
@@ -47,3 +45,6 @@ fix:
   languages:
     - Package XML
   time: 2013-10-09 (10:01)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: 9de969082a80944fa779a17a570877901289e31f

--- a/kobuki/a794de9/a794de9.bug
+++ b/kobuki/a794de9/a794de9.bug
@@ -31,10 +31,17 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/yujinrobot/kobuki
-  hash: a794de9b6567b69f6c4885a177d017685f518524 | 18b46dc557676adc00b9f17c09c3af5281b5ea88
-    | f62c63ff94ab65fb3218e647e3886636e250f189 | 193ba75ee7b08b8bdb09b5815e486948913e3442
-    | 936e46785de6ae1fc473ff670b07ab16016ab7ef
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: a794de9b6567b69f6c4885a177d017685f518524
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: 18b46dc557676adc00b9f17c09c3af5281b5ea88
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: f62c63ff94ab65fb3218e647e3886636e250f189
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: 193ba75ee7b08b8bdb09b5815e486948913e3442
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: 936e46785de6ae1fc473ff670b07ab16016ab7ef
   pull-request: null
   license: ['BSD']
   fix-in:

--- a/kobuki/acd5bfb/acd5bfb.bug
+++ b/kobuki/acd5bfb/acd5bfb.bug
@@ -29,8 +29,6 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/yujinrobot/kobuki_desktop
-  hash: acd5bfbd5513fb915d54fe7662fb345237f18490
   pull-request: null
   license: ['BSD']
   fix-in:
@@ -39,3 +37,6 @@ fix:
   languages:
     - C++
   time: 2013-08-29 (04:29)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki_desktop
+      hash: acd5bfbd5513fb915d54fe7662fb345237f18490

--- a/kobuki/ad906f0/ad906f0.bug
+++ b/kobuki/ad906f0/ad906f0.bug
@@ -32,11 +32,12 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/yujinrobot/kobuki
-  hash: ad906f0a6ebeb732afb5938f79200f8eb4bccabf
   pull-request: null
   license: ['BSD']
   fix-in: ['kobuki_driver/include/kobuki_driver/modules/gate_keeper.hpp', 'kobuki_driver/src/driver/kobuki.cpp']
   languages:
     - C++
   time: 2012-06-11 (04:40)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: ad906f0a6ebeb732afb5938f79200f8eb4bccabf

--- a/kobuki/af7946f/af7946f.bug
+++ b/kobuki/af7946f/af7946f.bug
@@ -30,11 +30,12 @@ bug:
   reproducibility: sometimes
   trace: null
 fix:
-  repo: https://github.com/yujinrobot/kobuki
-  hash: af7946f9b5a5a8536c5df6cbefc83b6020d38dd0
   pull-request: null
   license: ['BSD']
   fix-in: ['kobuki_driver/src/driver/diff_drive.cpp', 'kobuki_driver/src/test/velocity_commands.cpp']
   languages:
     - C++
   time: 2012-05-17 (12:12)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: af7946f9b5a5a8536c5df6cbefc83b6020d38dd0

--- a/kobuki/b166c93/b166c93.bug
+++ b/kobuki/b166c93/b166c93.bug
@@ -54,11 +54,12 @@ bug:
     was then called within the test case.
     This was the only change to the original code.
 fix:
-  repo: https://github.com/yujinrobot/kobuki_core
-  hash: b166c93913e293c55a3faa7b298c5f52f6def964
   pull-request: null
   license: ['BSD']
   fix-in: ['kobuki_driver/src/driver/kobuki.cpp']
   languages:
     - C++
   time: 2016-06-17 (08:57)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki_core
+      hash: b166c93913e293c55a3faa7b298c5f52f6def964

--- a/kobuki/b18f559/b18f559.bug
+++ b/kobuki/b18f559/b18f559.bug
@@ -30,8 +30,6 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/yujinrobot/kobuki
-  hash: b18f55910cc032f967b436b26710c01ec435291d
   pull-request: null
   license: ['BSD']
   fix-in:
@@ -42,3 +40,6 @@ fix:
   languages:
     - C++
   time: 2012-04-09 (06:34)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: b18f55910cc032f967b436b26710c01ec435291d

--- a/kobuki/b213df3/b213df3.bug
+++ b/kobuki/b213df3/b213df3.bug
@@ -43,11 +43,12 @@ bug:
     parameter that is created by mistake. The successful reading of this
     parameter should fail the test.
 fix:
-  repo: https://github.com/yujinrobot/kobuki
-  hash: b213df3324cd933ddfc1bbd7ef8dce50cc233d51
   pull-request: null
   license: ['BSD']
   fix-in: ['kobuki_node/param/base.yaml']
   languages:
     - Param YAML
   time: 2013-08-30 (09:45)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: b213df3324cd933ddfc1bbd7ef8dce50cc233d51

--- a/kobuki/b5f0943/b5f0943.bug
+++ b/kobuki/b5f0943/b5f0943.bug
@@ -38,10 +38,17 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/yujinrobot/kobuki
-  hash: 09059257fa3f5d0f475712ea7700f1d3dca9fe37 | 1f5e8b0ad3ec4aaf49fd52bd0b85d1480bee3c9f
-    | c830670377746302ca09aa1d484efcc0739a223c | b5f0943df63721e77ce137e73cb0537d19790d54
-    | 2fd8f8717e45604b06abf3df39e18b79a895f30c
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: 09059257fa3f5d0f475712ea7700f1d3dca9fe37
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: 1f5e8b0ad3ec4aaf49fd52bd0b85d1480bee3c9f
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: c830670377746302ca09aa1d484efcc0739a223c
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: b5f0943df63721e77ce137e73cb0537d19790d54
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: 2fd8f8717e45604b06abf3df39e18b79a895f30c
   pull-request: null
   license: ['BSD']
   fix-in:

--- a/kobuki/bb3c7ec/bb3c7ec.bug
+++ b/kobuki/bb3c7ec/bb3c7ec.bug
@@ -34,8 +34,6 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/yujinrobot/kobuki
-  hash: bb3c7ec8a7e656aa7e75753864351c27d571db47
   pull-request: null
   license: ['BSD']
   fix-in:
@@ -45,3 +43,6 @@ fix:
     - C++
     - Param YAML
   time: 2012-06-20 (04:01)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: bb3c7ec8a7e656aa7e75753864351c27d571db47

--- a/kobuki/c04eae5/c04eae5.bug
+++ b/kobuki/c04eae5/c04eae5.bug
@@ -28,8 +28,11 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/yujinrobot/kobuki
-  hash: c04eae575167f579f9fce4e11f212e6d73b3deac | d92a96e5a05f69c626132db42490ac382298df93
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: c04eae575167f579f9fce4e11f212e6d73b3deac
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: d92a96e5a05f69c626132db42490ac382298df93
   pull-request: null
   license: ['BSD']
   fix-in:

--- a/kobuki/d9aa656/d9aa656.bug
+++ b/kobuki/d9aa656/d9aa656.bug
@@ -30,11 +30,12 @@ bug:
   reproducibility: sometimes
   trace: null
 fix:
-  repo: https://github.com/yujinrobot/kobuki
-  hash: d9aa65681b3f10d0b6dda3d591a24b8be5119fb6
   pull-request: null
   license: ['BSD']
   fix-in: ['kobuki_bringup/resources/yaml/kobuki.yaml']
   languages:
     - Param YAML
   time: 2012-05-16 (17:29)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: d9aa65681b3f10d0b6dda3d591a24b8be5119fb6

--- a/kobuki/dbcdb12/dbcdb12.bug
+++ b/kobuki/dbcdb12/dbcdb12.bug
@@ -49,8 +49,6 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/yujinrobot/kobuki
-  hash: dbcdb12acb4b7811084d4f4dc75e0408b9899de0
   pull-request: null
   license: ['BSD']
   fix-in:
@@ -60,3 +58,6 @@ fix:
   languages:
     - C++
   time: 2012-12-04 (05:59)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: dbcdb12acb4b7811084d4f4dc75e0408b9899de0

--- a/kobuki/dd40270/dd40270.bug
+++ b/kobuki/dd40270/dd40270.bug
@@ -55,8 +55,6 @@ bug:
     used, due to the fact that the bugs reside in executable scripts, which
     are not part of the source code that is importable by standard means.
 fix:
-  repo: https://github.com/yujinrobot/kobuki
-  hash: dd40270d17cdd3e1729437f0988c0acb6c622d5e
   pull-request: null
   license: ['BSD']
   fix-in:
@@ -69,3 +67,6 @@ fix:
   languages:
     - Python
   time: 2014-08-11 (06:13)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: dd40270d17cdd3e1729437f0988c0acb6c622d5e

--- a/kobuki/e34428d/e34428d.bug
+++ b/kobuki/e34428d/e34428d.bug
@@ -28,11 +28,12 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/yujinrobot/kobuki
-  hash: e34428db1df893b36e604f17156837af3ab380cb
   pull-request: null
   license: ['BSD']
   fix-in: ['kobuki_node/scripts/laptop_battery.py']
   languages:
     - Python
   time: 2012-06-07 (00:55)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: e34428db1df893b36e604f17156837af3ab380cb

--- a/kobuki/e3c9bbc/e3c9bbc.bug
+++ b/kobuki/e3c9bbc/e3c9bbc.bug
@@ -43,8 +43,6 @@ bug:
     Besides, the fix occurs in the rosdistro repository, which does
     not contain a ROS package, and makes the reproduction process harder.
 fix:
-  repo: https://github.com/ros/rosdistro
-  hash: e3c9bbcd9a3c05a5375375732d52e185cca5afb0
   pull-request: https://github.com/ros/rosdistro/pull/4560
   license: ['BSD']
   fix-in:
@@ -52,3 +50,6 @@ fix:
   languages:
     - Other YAML
   time: 2014-05-28 (17:50)
+  commits:
+    - repo: https://github.com/ros/rosdistro
+      hash: e3c9bbcd9a3c05a5375375732d52e185cca5afb0

--- a/kobuki/e45b2b6/e45b2b6.bug
+++ b/kobuki/e45b2b6/e45b2b6.bug
@@ -29,11 +29,12 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/yujinrobot/kobuki
-  hash: e45b2b6a02152021764f3ca9d8d0ed17084c3bcd
   pull-request: null
   license: ['BSD']
   fix-in: ['kobuki_driver/include/kobuki_driver/kobuki.hpp', 'kobuki_driver/src/driver/kobuki.cpp']
   languages:
     - C++
   time: 2012-04-16 (10:51)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: e45b2b6a02152021764f3ca9d8d0ed17084c3bcd

--- a/kobuki/e964bbb/e964bbb.bug
+++ b/kobuki/e964bbb/e964bbb.bug
@@ -36,8 +36,6 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/yujinrobot/kobuki
-  hash: e964bbb8700fb1a9b95c0cfe5a44d43321294d4f
   pull-request: N/A
   license:
     - 'BSD'
@@ -46,6 +44,9 @@ fix:
   languages:
     - C++
   time: 2013-02-25T09:31:00Z
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: e964bbb8700fb1a9b95c0cfe5a44d43321294d4f
 time-machine:
   ros_distro: hydro
   ros_pkgs:

--- a/kobuki/eed104d/eed104d.bug
+++ b/kobuki/eed104d/eed104d.bug
@@ -50,11 +50,12 @@ bug:
       CMakeLists.txt:10 (catkin_package)
     -- Configuring incomplete, errors occurred!
 fix:
-  repo: https://github.com/yujinrobot/kobuki_core
-  hash: eed104dcdd8862824598838b65a7e2339f8e660a
   pull-request: null
   license: ['BSD']
   fix-in: ['kobuki_ftdi/package.xml']
   languages:
     - Package XML
   time: 2017-03-03 (00:11)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki_core
+      hash: eed104dcdd8862824598838b65a7e2339f8e660a

--- a/kobuki/f548cc7/f548cc7.bug
+++ b/kobuki/f548cc7/f548cc7.bug
@@ -45,10 +45,10 @@ bug:
         message =
     [FATAL] [1354029622.152687114]: Call to publish() on an invalid Publisher
     [FATAL] [1354029622.153042536]:
-    [keyop-1] process has died [pid 13442, exit code -5, cmd /opt/turtlebot_groovy/kobuki/kobuki_keyop/bin/keyop keyop/enable:=/enable keyop/disable:=/disable keyop/cmd_vel:=/cmd_vel keyop/mobile_robot/reset_odometry:=/mobile_base/reset_odometry __name:=keyop __log:=/home/yujin/.ros/log/97190902-3887-11e2-b4e2-0026c7d760cc/keyop-1.log].
+    [keyop-1] process has died [pid 13442, exit code -5, cmd /opt/turtlebot_groovy/kobuki/kobuki_keyop/bin/keyop
+    keyop/enable:=/enable keyop/disable:=/disable keyop/cmd_vel:=/cmd_vel keyop/mobile_robot/reset_odometry:=/mobile_base/reset_odometry
+    __name:=keyop __log:=/home/yujin/.ros/log/97190902-3887-11e2-b4e2-0026c7d760cc/keyop-1.log].
 fix:
-  repo: https://github.com/yujinrobot/kobuki
-  hash: f548cc73fb2959c7ceb6ab1c7f5a973bf95e5594
   pull-request: null
   license: ['BSD']
   fix-in:
@@ -60,3 +60,6 @@ fix:
     - C++
     - Package XML
   time: 2012-12-01 (06:26)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: f548cc73fb2959c7ceb6ab1c7f5a973bf95e5594

--- a/kobuki/f95c384/f95c384.bug
+++ b/kobuki/f95c384/f95c384.bug
@@ -28,11 +28,12 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/yujinrobot/kobuki
-  hash: f95c3847d97fba46b6317e00ffd78ce352ec376f
   pull-request: https://github.com/yujinrobot/kobuki/pull/334
   license: ['BSD']
   fix-in: ['kobuki_node/package.xml']
   languages:
     - Package XML
   time: 2014-08-08 (01:42)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: f95c3847d97fba46b6317e00ffd78ce352ec376f

--- a/kobuki/fbe70c7/fbe70c7.bug
+++ b/kobuki/fbe70c7/fbe70c7.bug
@@ -35,8 +35,6 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/yujinrobot/kobuki
-  hash: fbe70c7d5e6d3b85fea6296c23039958c428e6df
   pull-request: null
   license: ['BSD']
   fix-in:
@@ -45,3 +43,6 @@ fix:
   languages:
     - Launch XML
   time: 2012-04-05 (23:57)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: fbe70c7d5e6d3b85fea6296c23039958c428e6df

--- a/kobuki/fd6b589/fd6b589.bug
+++ b/kobuki/fd6b589/fd6b589.bug
@@ -28,8 +28,11 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/yujinrobot/kobuki_core | https://github.com/yujinrobot/kobuki
-  hash: fd6b589ccba8ed8531c66a806cb755074207a4c2 | 710e62408a0c6934e423411b9ae914fb26a3be49
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki_core
+      hash: fd6b589ccba8ed8531c66a806cb755074207a4c2
+    - repo: https://github.com/yujinrobot/kobuki
+      hash: 710e62408a0c6934e423411b9ae914fb26a3be49
   pull-request: null
   license: ['BSD']
   fix-in: ['kobuki_core/package.xml', 'kobuki/package.xml']

--- a/mavros/08cd181/08cd181.bug
+++ b/mavros/08cd181/08cd181.bug
@@ -31,8 +31,6 @@ bug:
   reproducibility: always
   trace: N/A
 fix:
-  repo: https://github.com/mavlink/mavros
-  hash: 08cd18164e729b0fb0ed1f6b553e5458eb9b6a4c
   pull-request: N/A
   license:
     - BSD
@@ -43,6 +41,9 @@ fix:
   languages:
     - C++
   time: 2014-11-02T20:19:36+03:00
+  commits:
+    - repo: https://github.com/mavlink/mavros
+      hash: 08cd18164e729b0fb0ed1f6b553e5458eb9b6a4c
 time-machine:
   ros_distro: hydro
   ros_pkgs:

--- a/mavros/0e2ea0c/0e2ea0c.bug
+++ b/mavros/0e2ea0c/0e2ea0c.bug
@@ -35,8 +35,6 @@ bug:
   reproducibility: N/A
   trace: N/A
 fix:
-  repo: https://github.com/mavlink/mavros
-  hash: 0e2ea0c43b373feb490b45710fb63f4e6cde78eb
   pull-request: N/A
   license:
     - BSD
@@ -47,6 +45,9 @@ fix:
   languages:
     - C++
   time: 2015-07-29T13:27:14+03:00
+  commits:
+    - repo: https://github.com/mavlink/mavros
+      hash: 0e2ea0c43b373feb490b45710fb63f4e6cde78eb
 time-machine:
   ros_distro: indigo
   ros_pkgs:

--- a/mavros/101c09b/101c09b.bug
+++ b/mavros/101c09b/101c09b.bug
@@ -28,8 +28,6 @@ bug:
   reproducibility: N/A
   trace: N/A
 fix:
-  repo: https://github.com/mavlink/mavros
-  hash: 101c09b7047eac18a2d9989b09c5916181a49cd5
   pull-request: N/A
   license:
     - BSD
@@ -40,6 +38,9 @@ fix:
   languages:
     - C++
   time: 2014-07-01T01:42:55+04:00
+  commits:
+    - repo: https://github.com/mavlink/mavros
+      hash: 101c09b7047eac18a2d9989b09c5916181a49cd5
 time-machine:
   datetime: 2014-07-01T01:42:55+04:00
   ros_distro: indigo

--- a/mavros/1a746c3/1a746c3.bug
+++ b/mavros/1a746c3/1a746c3.bug
@@ -30,8 +30,6 @@ bug:
   reproducibility: N/A
   trace: N/A
 fix:
-  repo: https://github.com/mavlink/mavros
-  hash: 1a746c326c49c0c265e01556bd4da45dadeacaa7
   pull-request: N/A
   license:
     - BSD
@@ -42,6 +40,9 @@ fix:
   languages:
     - C++
   time: 2016-06-28T21:38:47+03:00
+  commits:
+    - repo: https://github.com/mavlink/mavros
+      hash: 1a746c326c49c0c265e01556bd4da45dadeacaa7
 time-machine:
   ros_distro: kinetic
   ros_pkgs:

--- a/mavros/1f01916/1f01916.bug
+++ b/mavros/1f01916/1f01916.bug
@@ -35,8 +35,6 @@ bug:
   reproducibility: N/A
   trace: N/A
 fix:
-  repo: https://github.com/mavlink/mavros
-  hash: 1f019166ccedf8ce5151944f5e33302afaf82679
   pull-request: N/A
   license:
     - BSD
@@ -48,6 +46,9 @@ fix:
   languages:
     - C++
   time: 2014-08-04T15:14:53+04:00
+  commits:
+    - repo: https://github.com/mavlink/mavros
+      hash: 1f019166ccedf8ce5151944f5e33302afaf82679
 time-machine:
   ros_distro: hydro
   ros_pkgs:

--- a/mavros/215010d/215010d.bug
+++ b/mavros/215010d/215010d.bug
@@ -44,8 +44,6 @@ bug:
   reproducibility: N/A
   trace: N/A
 fix:
-  repo: https://github.com/mavlink/mavros
-  hash: 215010d25409211ccfb35375c218c74c921b1a3a
   pull-request: N/A
   license:
     - BSD
@@ -56,6 +54,9 @@ fix:
   languages:
     - C++
   datetime: 2014-07-01T01:15:08+04:00
+  commits:
+    - repo: https://github.com/mavlink/mavros
+      hash: 215010d25409211ccfb35375c218c74c921b1a3a
 time-machine:
   ros_distro: hydro
   ros_pkgs:

--- a/mavros/248cb38/248cb38.bug
+++ b/mavros/248cb38/248cb38.bug
@@ -36,8 +36,6 @@ bug:
   reproducibility: N/A
   trace: N/A
 fix:
-  repo: https://github.com/mavlink/mavros
-  hash: 248cb389b122fa94a68578a48e50d4f240df4629
   pull-request: N/A
   license:
     - BSD
@@ -48,6 +46,9 @@ fix:
   languages:
     - C++
   time: 2015-07-28T14:18:43-04:00
+  commits:
+    - repo: https://github.com/mavlink/mavros
+      hash: 248cb389b122fa94a68578a48e50d4f240df4629
 time-machine:
   ros_distro: indigo
   ros_pkgs:

--- a/mavros/263650d/263650d.bug
+++ b/mavros/263650d/263650d.bug
@@ -30,8 +30,6 @@ bug:
   reproducibility: N/A
   trace: N/A
 fix:
-  repo: https://github.com/mavlink/mavros
-  hash: 263650d6c1a9c9aebc6b8a0e3ea4627e59c58a77
   pull-request: N/A
   license:
     - BSD
@@ -42,6 +40,9 @@ fix:
   languages:
     - Python
   time: 2015-08-04T01:23:24+03:00
+  commits:
+    - repo: https://github.com/mavlink/mavros
+      hash: 263650d6c1a9c9aebc6b8a0e3ea4627e59c58a77
 time-machine:
   ros_distro: indigo
   ros_pkgs:

--- a/mavros/27e7db9/27e7db9.bug
+++ b/mavros/27e7db9/27e7db9.bug
@@ -29,8 +29,6 @@ bug:
   reproducibility: N/A
   trace: N/A
 fix:
-  repo: https://github.com/mavlink/mavros
-  hash: 27e7db9d504359d05830fbc9553fd1fd1af3aab2
   pull-request: N/A
   license:
     - BSD
@@ -40,6 +38,9 @@ fix:
   languages:
     - CMake
   time: 2014-11-03T12:18:48+03:00
+  commits:
+    - repo: https://github.com/mavlink/mavros
+      hash: 27e7db9d504359d05830fbc9553fd1fd1af3aab2
 time-machine:
   ros_distro: hydro
   ros_pkgs:

--- a/mavros/282c9be/282c9be.bug
+++ b/mavros/282c9be/282c9be.bug
@@ -29,8 +29,6 @@ bug:
   reproducibility: N/A
   trace: N/A
 fix:
-  repo: https://github.com/mavlink/mavros
-  hash: 282c9bece1fa7bc87db070d836127b52bb9d1306
   pull-request: N/A
   license:
     - BSD
@@ -41,6 +39,9 @@ fix:
   languages:
     - C++
   time: 2014-07-26T13:14:56+04:00
+  commits:
+    - repo: https://github.com/mavlink/mavros
+      hash: 282c9bece1fa7bc87db070d836127b52bb9d1306
 time-machine:
   ros_distro: hydro
   ros_pkgs:

--- a/mavros/2998e9f/2998e9f.bug
+++ b/mavros/2998e9f/2998e9f.bug
@@ -35,8 +35,6 @@ bug:
   reproducibility: N/A
   trace: N/A
 fix:
-  repo: https://github.com/mavlink/mavros
-  hash: 2998e9f7f9e0fb969e7248a46d5ecd0749614d06
   pull-request: N/A
   license:
     - BSD
@@ -47,6 +45,9 @@ fix:
   languages:
     - C++
   time: 2014-01-13 (00:00)
+  commits:
+    - repo: https://github.com/mavlink/mavros
+      hash: 2998e9f7f9e0fb969e7248a46d5ecd0749614d06
 time-machine:
   ros_distro: hydro
   ros_pkgs:

--- a/mavros/29af3a3/29af3a3.bug
+++ b/mavros/29af3a3/29af3a3.bug
@@ -47,8 +47,6 @@ bug:
   reproducibility: N/A
   trace: N/A
 fix:
-  repo: https://github.com/mavlink/mavros
-  hash: 29af3a3c14da0e5b92ebad40b8befa8e0141b63d
   pull-request: https://github.com/mavlink/mavros/pull/527
   license:
     - BSD
@@ -59,6 +57,9 @@ fix:
   languages:
     - C++
   time: 2016-03-27T20:53:24-04:00
+  commits:
+    - repo: https://github.com/mavlink/mavros
+      hash: 29af3a3c14da0e5b92ebad40b8befa8e0141b63d
 time-machine:
   ros_distro: indigo
   ros_pkgs:

--- a/mavros/31ad11d/31ad11d.bug
+++ b/mavros/31ad11d/31ad11d.bug
@@ -34,8 +34,6 @@ bug:
   reproducibility: N/A
   trace: N/A
 fix:
-  repo: https://github.com/mavlink/mavros
-  hash: 31ad11dc57aaf7dfac6f8d810162184b0f4d3ef4
   pull-request: N/A
   license:
     - BSD
@@ -47,6 +45,9 @@ fix:
   languages:
     - C++
   time: 2017-02-07 (00:00)
+  commits:
+    - repo: https://github.com/mavlink/mavros
+      hash: 31ad11dc57aaf7dfac6f8d810162184b0f4d3ef4
 time-machine:
   ros_distro: kinetic
   ros_pkgs:

--- a/mavros/400949c/400949c.bug
+++ b/mavros/400949c/400949c.bug
@@ -40,8 +40,6 @@ bug:
   reproducibility: N/A
   trace: N/A
 fix:
-  repo: https://github.com/mavlink/mavros
-  hash: 400949c5b152a888a8b4fd94b085bbfc2092f146
   pull-request: N/A
   license:
     - BSD
@@ -58,6 +56,9 @@ fix:
   languages:
     - C++
   time: 2016-06-06 (00:00)
+  commits:
+    - repo: https://github.com/mavlink/mavros
+      hash: 400949c5b152a888a8b4fd94b085bbfc2092f146
 time-machine:
   ros_distro: kinetic
   ros_pkgs:

--- a/mavros/4fb6e7e/4fb6e7e.bug
+++ b/mavros/4fb6e7e/4fb6e7e.bug
@@ -47,8 +47,6 @@ bug:
   reproducibility: N/A
   trace: N/A
 fix:
-  repo: https://github.com/mavlink/mavros
-  hash: 4fb6e7e8190145ba6fa49fa6e13cc49730885b7f
   pull-request: N/A
   license:
     - BSD
@@ -59,6 +57,9 @@ fix:
   languages:
     - C++
   time: 2015-08-02T16:13:18+03:00
+  commits:
+    - repo: https://github.com/mavlink/mavros
+      hash: 4fb6e7e8190145ba6fa49fa6e13cc49730885b7f
 time-machine:
   ros_distro: indigo
   ros_pkgs:

--- a/mavros/5353982/5353982.bug
+++ b/mavros/5353982/5353982.bug
@@ -38,8 +38,6 @@ bug:
   reproducibility: N/A
   trace: N/A
 fix:
-  repo: https://github.com/mavlink/mavros
-  hash: 5353982ea0f32783fcf3e296b25ab3b253550201
   pull-request: N/A
   license:
     - BSD
@@ -50,6 +48,9 @@ fix:
   languages:
     - C++
   time: 2016-01-31T09:23:07-05:00
+  commits:
+    - repo: https://github.com/mavlink/mavros
+      hash: 5353982ea0f32783fcf3e296b25ab3b253550201
 time-machine:
   ros_distro: indigo
   ros_pkgs:

--- a/mavros/564f935/564f935.bug
+++ b/mavros/564f935/564f935.bug
@@ -42,8 +42,6 @@ bug:
   reproducibility: N/A
   trace: N/A
 fix:
-  repo: https://github.com/mavlink/mavros
-  hash: 564f935bc1ddd6c7849923a647ebd3828cde99f0
   pull-request: N/A
   license:
     - BSD
@@ -54,6 +52,9 @@ fix:
   languages:
     - Python
   time: 2015-06-16T23:12:18+05:30
+  commits:
+    - repo: https://github.com/mavlink/mavros
+      hash: 564f935bc1ddd6c7849923a647ebd3828cde99f0
 time-machine:
   ros_distro: indigo
   ros_pkgs:

--- a/mavros/594978d/594978d.bug
+++ b/mavros/594978d/594978d.bug
@@ -40,8 +40,6 @@ bug:
   reproducibility: N/A
   trace: N/A
 fix:
-  repo: https://github.com/mavlink/mavros
-  hash: 594978da8302b6194bcf63c8119e3b3801242acd
   pull-request: N/A
   license:
     - BSD
@@ -52,6 +50,9 @@ fix:
   languages:
     - C++
   time: 2015-09-16T17:18:35+03:00
+  commits:
+    - repo: https://github.com/mavlink/mavros
+      hash: 594978da8302b6194bcf63c8119e3b3801242acd
 time-machine:
   ros_distro: jade
   ros_pkgs:

--- a/mavros/599c588/599c588.bug
+++ b/mavros/599c588/599c588.bug
@@ -39,8 +39,6 @@ bug:
   reproducibility: N/A
   trace: N/A
 fix:
-  repo: https://github.com/mavlink/mavros
-  hash: 599c5887ad2aadc124d7e1354f3a1597402118da
   pull-request: N/A
   license:
     - BSD
@@ -55,6 +53,9 @@ fix:
     - Python
     - C++
   time: 2017-06-28 (00:00)
+  commits:
+    - repo: https://github.com/mavlink/mavros
+      hash: 599c5887ad2aadc124d7e1354f3a1597402118da
 time-machine:
   ros_distro: kinetic
   ros_pkgs:

--- a/mavros/6bb2672/6bb2672.bug
+++ b/mavros/6bb2672/6bb2672.bug
@@ -34,8 +34,6 @@ bug:
   reproducibility: N/A
   trace: N/A
 fix:
-  repo: https://github.com/mavlink/mavros
-  hash: 6bb267295ec87d8a089cc0f2f7d23555ea342943
   pull-request: N/A
   license:
     - BSD
@@ -46,6 +44,9 @@ fix:
   languages:
     - C++
   time: 2017-03-30T11:08:19+03:00
+  commits:
+    - repo: https://github.com/mavlink/mavros
+      hash: 6bb267295ec87d8a089cc0f2f7d23555ea342943
 time-machine:
   ros_distro: kinetic
   ros_pkgs:

--- a/mavros/753226d/753226d.bug
+++ b/mavros/753226d/753226d.bug
@@ -36,8 +36,6 @@ bug:
   reproducibility: N/A
   trace: N/A
 fix:
-  repo: https://github.com/mavlink/mavros
-  hash: 753226d93a735ba01744620b5654b8a038d1c89d
   pull-request: N/A
   license:
     - BSD
@@ -48,6 +46,9 @@ fix:
   languages:
     - C++
   time: 2015-09-17T19:22:06+03:00
+  commits:
+    - repo: https://github.com/mavlink/mavros
+      hash: 753226d93a735ba01744620b5654b8a038d1c89d
 time-machine:
   ros_distro: indigo
   ros_pkgs:

--- a/mavros/7c6514d/7c6514d.bug
+++ b/mavros/7c6514d/7c6514d.bug
@@ -33,8 +33,6 @@ bug:
   reproducibility: N/A
   trace: N/A
 fix:
-  repo: https://github.com/mavlink/mavros
-  hash: 7c6514d3d5ec3c9f75b32db9054d468c49dbdfe8
   pull-request: https://github.com/mavlink/mavros/pull/296
   license:
     - BSD
@@ -45,6 +43,9 @@ fix:
   languages:
     - C++
   time: 2015-05-21T08:55:38+01:00
+  commits:
+    - repo: https://github.com/mavlink/mavros
+      hash: 7c6514d3d5ec3c9f75b32db9054d468c49dbdfe8
 time-machine:
   ros_distro: indigo
   ros_pkgs:

--- a/mavros/84264f0/84264f0.bug
+++ b/mavros/84264f0/84264f0.bug
@@ -35,8 +35,6 @@ bug:
   reproducibility: N/A
   trace: N/A
 fix:
-  repo: https://github.com/mavlink/mavros
-  hash: 84264f01aeea79b345fe9f397da8c4759b7846fb
   pull-request: N/A
   license:
     - BSD
@@ -47,6 +45,9 @@ fix:
   languages:
     - C++
   time: 2015-03-05 (00:00)
+  commits:
+    - repo: https://github.com/mavlink/mavros
+      hash: 84264f01aeea79b345fe9f397da8c4759b7846fb
 time-machine:
   ros_distro: indigo
   ros_pkgs:

--- a/mavros/86255ba/86255ba.bug
+++ b/mavros/86255ba/86255ba.bug
@@ -35,8 +35,6 @@ bug:
   reproducibility: N/A
   trace: N/A
 fix:
-  repo: https://github.com/mavlink/mavros
-  hash: 86255bac0538d4167de9d2bb9df59b88c587167f
   pull-request: N/A
   license:
     - BSD
@@ -47,6 +45,9 @@ fix:
   languages:
     - C++
   time: 2015-04-18T15:40:03+03:00
+  commits:
+    - repo: https://github.com/mavlink/mavros
+      hash: 86255bac0538d4167de9d2bb9df59b88c587167f
 time-machine:
   ros_distro: indigo
   ros_pkgs:

--- a/mavros/942eb3b/942eb3b.bug
+++ b/mavros/942eb3b/942eb3b.bug
@@ -27,8 +27,6 @@ bug:
   reproducibility: N/A
   trace: N/A
 fix:
-  repo: https://github.com/mavlink/mavros
-  hash: 942eb3b173b97c66c8cb8df213acf01d32642002
   pull-request: N/A
   license:
     - BSD
@@ -39,6 +37,9 @@ fix:
   languages:
     - CMake
   time: 2014-11-02 (00:00)
+  commits:
+    - repo: https://github.com/mavlink/mavros
+      hash: 942eb3b173b97c66c8cb8df213acf01d32642002
 time-machine:
   ros_distro: hydro
   ros_pkgs:

--- a/mavros/a67d81d/a67d81d.bug
+++ b/mavros/a67d81d/a67d81d.bug
@@ -36,8 +36,6 @@ bug:
   reproducibility: N/A
   trace: N/A
 fix:
-  repo: https://github.com/mavlink/mavros
-  hash: a67d81d05776a5431e9c0e77f51602ce7987fc7b
   pull-request: None
   license:
     - BSD
@@ -48,6 +46,9 @@ fix:
   languages:
     - C++
   time: 2015-06-17T00:23:26+03:00
+  commits:
+    - repo: https://github.com/mavlink/mavros
+      hash: a67d81d05776a5431e9c0e77f51602ce7987fc7b
 time-machine:
   ros_distro: indigo
   ros_pkgs:

--- a/mavros/b6b9754/b6b9754.bug
+++ b/mavros/b6b9754/b6b9754.bug
@@ -28,8 +28,6 @@ bug:
   reproducibility: N/A
   trace: N/A
 fix:
-  repo: https://github.com/mavlink/mavros
-  hash: b6b975421c8242fad83138a67fb026ef0d90704d
   pull-request: N/A
   license:
     - BSD
@@ -40,6 +38,9 @@ fix:
   languages:
     - C++
   datetime: 2015-03-01T20:23:52+01:00
+  commits:
+    - repo: https://github.com/mavlink/mavros
+      hash: b6b975421c8242fad83138a67fb026ef0d90704d
 time-machine:
   ros_distro: indigo
   ros_pkgs:

--- a/mavros/b96bf67/b96bf67.bug
+++ b/mavros/b96bf67/b96bf67.bug
@@ -34,8 +34,6 @@ bug:
   reproducibility: N/A
   trace: N/A
 fix:
-  repo: https://github.com/mavlink/mavros
-  hash: b96bf672a718b9f0c9694e4314283e385ba96231
   pull-request: https://github.com/mavlink/mavros/pull/537
   license:
     - BSD
@@ -46,6 +44,9 @@ fix:
   languages:
     - C++
   time: 2016-04-29T13:59:23-04:00
+  commits:
+    - repo: https://github.com/mavlink/mavros
+      hash: b96bf672a718b9f0c9694e4314283e385ba96231
 time-machine:
   ros_distro: indigo
   ros_pkgs:

--- a/mavros/bdda1fa/bdda1fa.bug
+++ b/mavros/bdda1fa/bdda1fa.bug
@@ -40,8 +40,6 @@ bug:
   reproducibility: N/A
   trace: N/A
 fix:
-  repo: https://github.com/mavlink/mavros
-  hash: bdda1fab32a9d084cfe980fe4f364b5eb35173e0
   pull-request: N/A
   license:
     - BSD
@@ -53,6 +51,9 @@ fix:
   languages:
     - Python
   time: 2016-01-22T09:10:42+03:00
+  commits:
+    - repo: https://github.com/mavlink/mavros
+      hash: bdda1fab32a9d084cfe980fe4f364b5eb35173e0
 time-machine:
   ros_distro: indigo
   ros_pkgs:

--- a/mavros/c0067f9/c0067f9.bug
+++ b/mavros/c0067f9/c0067f9.bug
@@ -28,8 +28,6 @@ bug:
   reproducibility: N/A
   trace: N/A
 fix:
-  repo: https://github.com/mavlink/mavros
-  hash: c0067f9f27a5a6ef5354e06fea18279541934520
   pull-request: N/A
   license:
     - BSD
@@ -40,6 +38,9 @@ fix:
   languages:
     - Python
   time: 2015-11-13T08:25:02+03:00
+  commits:
+    - repo: https://github.com/mavlink/mavros
+      hash: c0067f9f27a5a6ef5354e06fea18279541934520
 time-machine:
   ros_distro: indigo
   ros_pkgs:

--- a/mavros/c159041/c159041.bug
+++ b/mavros/c159041/c159041.bug
@@ -34,8 +34,6 @@ bug:
   reproducibility: N/A
   trace: N/A
 fix:
-  repo: https://github.com/mavlink/mavros
-  hash: c15904101ca0ecc8aa13712d92cc5382ddc0af18
   pull-request: N/A
   license:
     - BSD
@@ -46,6 +44,9 @@ fix:
   languages:
     - C++
   time: 2015-08-07T20:52:57-04:00
+  commits:
+    - repo: https://github.com/mavlink/mavros
+      hash: c15904101ca0ecc8aa13712d92cc5382ddc0af18
 time-machine:
   ros_distro: indigo
   ros_pkgs:

--- a/mavros/c172409/c172409.bug
+++ b/mavros/c172409/c172409.bug
@@ -44,8 +44,6 @@ bug:
   reproducibility: N/A
   trace: N/A
 fix:
-  repo: https://github.com/mavlink/mavros
-  hash: c172409eb3ae3ccce78697d4097db6ed5d9d5721
   pull-request: N/A
   license:
     - BSD
@@ -56,6 +54,9 @@ fix:
   languages:
     - C++
   time: 2016-09-30T18:53:40+03:00
+  commits:
+    - repo: https://github.com/mavlink/mavros
+      hash: c172409eb3ae3ccce78697d4097db6ed5d9d5721
 time-machine:
   ros_distro: kinetic
   ros_pkgs:

--- a/mavros/c6791f0/c6791f0.bug
+++ b/mavros/c6791f0/c6791f0.bug
@@ -42,8 +42,6 @@ bug:
   reproducibility: N/A
   trace: N/A
 fix:
-  repo: https://github.com/mavlink/mavros
-  hash: c6791f0f232e85f51cbb9e12d32f791588f5c93a
   pull-request: N/A
   license:
     - BSD
@@ -54,6 +52,9 @@ fix:
   languages:
     - Python
   time: 2015-12-05T02:20:03+03:00
+  commits:
+    - repo: https://github.com/mavlink/mavros
+      hash: c6791f0f232e85f51cbb9e12d32f791588f5c93a
 time-machine:
   ros_distro: indigo
   ros_pkgs:

--- a/mavros/dab1b8a/dab1b8a.bug
+++ b/mavros/dab1b8a/dab1b8a.bug
@@ -28,8 +28,6 @@ bug:
   reproducibility: N/A
   trace: N/A
 fix:
-  repo: https://github.com/mavlink/mavros
-  hash: dab1b8a16d6194056cb7e76215ecf299d1a90f08
   pull-request: https://github.com/mavlink/mavros/pull/230
   license:
     - BSD
@@ -39,6 +37,9 @@ fix:
   languages:
     - C++
   time: 2015-03-01T02:13:01+01:00
+  commits:
+    - repo: https://github.com/mavlink/mavros
+      hash: dab1b8a16d6194056cb7e76215ecf299d1a90f08
 time-machine:
   ros_distro: indigo
   ros_pkgs:

--- a/mavros/dc1327f/dc1327f.bug
+++ b/mavros/dc1327f/dc1327f.bug
@@ -28,8 +28,6 @@ bug:
   reproducibility: N/A
   trace: N/A
 fix:
-  repo: https://github.com/mavlink/mavros
-  hash: dc1327f35887f9337bb4f29bb94fb8a5c5fa8a73
   pull-request: N/A
   license:
     - BSD
@@ -40,3 +38,6 @@ fix:
   languages:
     - Package XML
   time: 2013-11-03 (00:00)
+  commits:
+    - repo: https://github.com/mavlink/mavros
+      hash: dc1327f35887f9337bb4f29bb94fb8a5c5fa8a73

--- a/mavros/de2cc36/de2cc36.bug
+++ b/mavros/de2cc36/de2cc36.bug
@@ -33,8 +33,6 @@ bug:
   reproducibility: N/A
   trace: N/A
 fix:
-  repo: https://github.com/mavlink/mavros
-  hash: de2cc36b37689363f60876d9892f2630173b4f8c
   pull-request: N/A
   license:
     - BSD
@@ -45,6 +43,9 @@ fix:
   languages:
     - C++
   time: 2016-06-23 (00:00)
+  commits:
+    - repo: https://github.com/mavlink/mavros
+      hash: de2cc36b37689363f60876d9892f2630173b4f8c
 time-machine:
   ros_distro: indigo
   ros_pkgs:

--- a/mavros/e05c71a/e05c71a.bug
+++ b/mavros/e05c71a/e05c71a.bug
@@ -41,8 +41,6 @@ bug:
   reproducibility: N/A
   trace: N/A
 fix:
-  repo: https://github.com/mavlink/mavros
-  hash: e05c71a824cc1525d7cecb9a5ed021346cea7c8f
   pull-request: N/A
   license:
     - BSD
@@ -59,3 +57,6 @@ fix:
     - srv
     - CMake
   time: 2015-08-09 (00:00)
+  commits:
+    - repo: https://github.com/mavlink/mavros
+      hash: e05c71a824cc1525d7cecb9a5ed021346cea7c8f

--- a/mavros/e1a8005/e1a8005.bug
+++ b/mavros/e1a8005/e1a8005.bug
@@ -37,8 +37,6 @@ bug:
   reproducibility: N/A
   trace: N/A
 fix:
-  repo: https://github.com/mavlink/mavros
-  hash: e1a80052fbdb8324573c8cce0401b01aa78765ae
   pull-request: N/A
   license:
     - BSD
@@ -49,6 +47,9 @@ fix:
   languages:
     - C++
   time: 2015-03-11T13:27:29+03:00
+  commits:
+    - repo: https://github.com/mavlink/mavros
+      hash: e1a80052fbdb8324573c8cce0401b01aa78765ae
 time-machine:
   ros_distro: indigo
   ros_pkgs:

--- a/mavros/fcf9cd9/fcf9cd9.bug
+++ b/mavros/fcf9cd9/fcf9cd9.bug
@@ -35,8 +35,6 @@ bug:
   reproducibility: N/A
   trace: N/A
 fix:
-  repo: https://github.com/mavlink/mavros
-  hash: fcf9cd9de383a20bb98dad3040cc0a6204cb9e10
   pull-request: N/A
   license:
     - BSD
@@ -47,6 +45,9 @@ fix:
   languages:
     - C++
   time: 2015-09-17T20:05:12+03:00
+  commits:
+    - repo: https://github.com/mavlink/mavros
+      hash: fcf9cd9de383a20bb98dad3040cc0a6204cb9e10
 time-machine:
   ros_distro: indigo
   ros_pkgs:

--- a/mavros/ff581a0/ff581a0.bug
+++ b/mavros/ff581a0/ff581a0.bug
@@ -36,8 +36,6 @@ bug:
   reproducibility: N/A
   trace: N/A
 fix:
-  repo: https://github.com/mavlink/mavros
-  hash: ff581a0752107f7ad875c16f83f7b75ccd92f847
   pull-request: https://github.com/mavlink/mavros/pull/296 # part of this PR, but there are 37 other commits in it
   license:
     - BSD
@@ -48,6 +46,9 @@ fix:
   languages:
     - C++
   time: 2015-05-17T04:28:48+01:00
+  commits:
+    - repo: https://github.com/mavlink/mavros
+      hash: ff581a0752107f7ad875c16f83f7b75ccd92f847
 time-machine:
   ros_distro: indigo
   ros_pkgs:

--- a/motoman/045ab54/045ab54.bug
+++ b/motoman/045ab54/045ab54.bug
@@ -28,6 +28,7 @@ bug:
   reproducibility: always
   trace: N/A
 fix:
+  # TODO we need to come up with and consistently apply a policy for forks
   repo: https://github.com/JeremyZoss/motoman | https://github.com/ros-industrial/motoman
   hash: null
   pull-request: 63

--- a/motoman/045ab54/045ab54.bug
+++ b/motoman/045ab54/045ab54.bug
@@ -28,10 +28,9 @@ bug:
   reproducibility: always
   trace: N/A
 fix:
-  # TODO we need to come up with and consistently apply a policy for forks
-  repo: https://github.com/JeremyZoss/motoman | https://github.com/ros-industrial/motoman
-  hash: null
-  pull-request: 63
+  repo: https://github.com/ros-industrial/motoman
+  hash: 045ab5403733ee9ec2512ee4d22e541dd3d6424f
+  pull-request: https://github.com/ros-industrial/motoman/pull/63
   license: ['BSD']
   fix-in: ['motoman_driver/CMakeLists.txt']
   languages:

--- a/motoman/0829607/0829607.bug
+++ b/motoman/0829607/0829607.bug
@@ -35,5 +35,5 @@ fix:
     - STL
   time: 2016-08-29 (13:15)
   commits:
-    - repo: https://github.com/gavanderhoorn/motoman
-      hash: 57b7a995dfdcf025d6394123eb87896853a6aadf
+    - repo: https://github.com/ros-industrial/motoman
+      hash: 082960760dd90c4040e394721b3991f4e17aac2d

--- a/motoman/0829607/0829607.bug
+++ b/motoman/0829607/0829607.bug
@@ -28,11 +28,12 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/gavanderhoorn/motoman
-  hash: 57b7a995dfdcf025d6394123eb87896853a6aadf
   pull-request: null
   license: null
   fix-in: ['motoman_sda10f_support/meshes/sda10f/visual/motoman_axis_b1.stl', 'motoman_sda10f_support/meshes/sda10f/visual/motoman_base.stl']
   languages:
     - STL
   time: 2016-08-29 (13:15)
+  commits:
+    - repo: https://github.com/gavanderhoorn/motoman
+      hash: 57b7a995dfdcf025d6394123eb87896853a6aadf

--- a/motoman/1ec8ca1/1ec8ca1.bug
+++ b/motoman/1ec8ca1/1ec8ca1.bug
@@ -27,8 +27,9 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/ros-industrial/motoman
-  hash: null
+  commits:
+    - repo: https://github.com/ros-industrial/motoman
+      hash: 1ec8ca1bb14fb68bac9672988ea311cdae7997c5
   pull-request: 175
   license: null
   fix-in: ['motoman_mh5_support/urdf/mh5_macro.xacros']

--- a/motoman/259b468/259b468.bug
+++ b/motoman/259b468/259b468.bug
@@ -27,8 +27,6 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/gavanderhoorn/motoman
-  hash: 5a10873b8d0ee01f457996840dde8d2d2daaf24f
   pull-request: null
   license: null
   fix-in:
@@ -36,3 +34,6 @@ fix:
   languages:
     - CMake
   time: 2016-09-06 (18:10)
+  commits:
+    - repo: https://github.com/gavanderhoorn/motoman
+      hash: 5a10873b8d0ee01f457996840dde8d2d2daaf24f

--- a/motoman/259b468/259b468.bug
+++ b/motoman/259b468/259b468.bug
@@ -35,5 +35,5 @@ fix:
     - CMake
   time: 2016-09-06 (18:10)
   commits:
-    - repo: https://github.com/gavanderhoorn/motoman
-      hash: 5a10873b8d0ee01f457996840dde8d2d2daaf24f
+    - repo: https://github.com/ros-industrial/motoman
+      hash: 259b468ea17fa680e68a0b91f57a2b58fa99b9bb

--- a/motoman/292b5cc/292b5cc.bug
+++ b/motoman/292b5cc/292b5cc.bug
@@ -30,11 +30,12 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/ros-industrial/motoman/
-  hash: 292b5cc8a10a640a8b364a529e3eadffffc9b56b
   pull-request: null
   license: ['BSD']
   fix-in: ['fs100/MotoPlus/MotionServer.c', 'fs100/MotoPlus/SimpleMessage.c', 'fs100/MotoPlus/output/MPRosFS100.out']
   languages:
     - C
   time: 2013-06-18 (21:23)
+  commits:
+    - repo: https://github.com/ros-industrial/motoman/
+      hash: 292b5cc8a10a640a8b364a529e3eadffffc9b56b

--- a/motoman/292b5cc/292b5cc.bug
+++ b/motoman/292b5cc/292b5cc.bug
@@ -37,5 +37,5 @@ fix:
     - C
   time: 2013-06-18 (21:23)
   commits:
-    - repo: https://github.com/ros-industrial/motoman/
+    - repo: https://github.com/ros-industrial/motoman
       hash: 292b5cc8a10a640a8b364a529e3eadffffc9b56b

--- a/motoman/2d42582/2d42582.bug
+++ b/motoman/2d42582/2d42582.bug
@@ -40,5 +40,5 @@ fix:
     - Xacro
   time: 2016-06-19 (00:00)
   commits:
-    - repo: https://github.com/gavanderhoorn/motoman
-      hash: 93a9abae92b51ed79b6909397940e26d379eaa94
+    - repo: https://github.com/ros-industrial/motoman
+      hash: 2d42582c692191f67f1e986467822fcd3b3935b9

--- a/motoman/2d42582/2d42582.bug
+++ b/motoman/2d42582/2d42582.bug
@@ -32,8 +32,6 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/gavanderhoorn/motoman
-  hash: 93a9abae92b51ed79b6909397940e26d379eaa94
   pull-request: null
   license: ['BSD']
   fix-in: ['motoman_sia20d_support/urdf/sia20d.urdf', 'motoman_sia20d_support/urdf/sia20d_macro.xacro']
@@ -41,3 +39,6 @@ fix:
     - URDF
     - Xacro
   time: 2016-06-19 (00:00)
+  commits:
+    - repo: https://github.com/gavanderhoorn/motoman
+      hash: 93a9abae92b51ed79b6909397940e26d379eaa94

--- a/motoman/3236783/3236783.bug
+++ b/motoman/3236783/3236783.bug
@@ -30,8 +30,11 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/ros-industrial/motoman/
-  hash: null
+  commits:
+    - repo: https://github.com/ros-industrial/motoman
+      hash: 62fa484b9d965d1ee2c6229f56bcaf76fe76fc52
+    - repo: https://github.com/ros-industrial/motoman
+      hash: 734602adadd454efe092957a35a54950dcf7cb02
   pull-request: 11 | 14
   license: ['BSD']
   fix-in: ['158 files due to a complete update of the driver package.']

--- a/motoman/377d7be/377d7be.bug
+++ b/motoman/377d7be/377d7be.bug
@@ -33,8 +33,9 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/ros-industrial/motoman
-  hash: null
+  commits:
+    - repo: https://github.com/ros-industrial/motoman
+      hash: 377d7bee86c5fc6130ad1e8b23f7893e58d42d18
   pull-request: 147
   license: ['BSD']
   fix-in:

--- a/motoman/3f260cb/3f260cb.bug
+++ b/motoman/3f260cb/3f260cb.bug
@@ -30,8 +30,9 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/ros-industrial/motoman
-  hash: null
+  commits:
+    - repo: https://github.com/ros-industrial/motoman
+      hash: 3f260cb3840095089fb4b743efd3d41695c75b26
   pull-request: 155
   license: ['BSD']
   fix-in: ['motoman_driver/include/motoman_driver/joint_trajectory_streamer.h', 'motoman_driver/src/joint_trajectory_streamer.cpp']

--- a/motoman/4089660/4089660.bug
+++ b/motoman/4089660/4089660.bug
@@ -28,8 +28,9 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/ros-industrial/motoman
-  hash: null
+  commits:
+    - repo: https://github.com/ros-industrial/motoman
+      hash: 40896603425f73b98b2b3b3631d5b367c61fae4d
   pull-request: 140
   license: ['BSD']
   fix-in:

--- a/motoman/65e7ee6/65e7ee6.bug
+++ b/motoman/65e7ee6/65e7ee6.bug
@@ -28,8 +28,9 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/ros-industrial/motoman/
-  hash: null
+  commits:
+    - repo: https://github.com/ros-industrial/motoman
+      hash: 65e7ee626aa5b180dd6c2a374ac7fc5b5dade26e
   pull-request: 15
   license: ['BSD']
   fix-in:

--- a/motoman/6a7a506/6a7a506.bug
+++ b/motoman/6a7a506/6a7a506.bug
@@ -29,8 +29,9 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/ros-industrial/motoman
-  hash: null
+  commits:
+    - repo: https://github.com/ros-industrial/motoman
+      hash: 6a7a506290af111727ececa3baaee9f7afed58a7
   pull-request: 94
   license: ['BSD']
   fix-in: ['motoman_sia5d_support/urdf/sia5d.urdf', 'motoman_sia5d_support/urdf/sia5d_macro.xacro']

--- a/motoman/6c89ebf/6c89ebf.bug
+++ b/motoman/6c89ebf/6c89ebf.bug
@@ -26,8 +26,9 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/ros-industrial/motoman/
-  hash: null
+  commits:
+    - repo: https://github.com/ros-industrial/motoman
+      hash: e8d6b47acb7884db8387389e94ed63d795c6aafe
   pull-request: 30
   license: ['BSD']
   fix-in: ['motoman_sia5d_support/urdf/sia5d.urdf', 'motoman_sia5d_support/urdf/sia5d_macro.xacro']

--- a/motoman/90a9464/90a9464.bug
+++ b/motoman/90a9464/90a9464.bug
@@ -27,8 +27,9 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/ros-industrial/motoman
-  hash: null
+  commits:
+    - repo: https://github.com/ros-industrial/motoman
+      hash: 90a94642f763903f71536dc972782a237309a7f1
   pull-request: 169
   license: ['BSD']
   fix-in:

--- a/motoman/91072e8/91072e8.bug
+++ b/motoman/91072e8/91072e8.bug
@@ -29,8 +29,9 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/ros-industrial/motoman
-  hash: null
+  commits:
+    - repo: https://github.com/ros-industrial/motoman
+      hash: 91072e8c8e680cb700f10d91b1ba01ba5875ff00
   pull-request: 12
   license: ['BSD']
   fix-in:

--- a/motoman/9bf25ea/9bf25ea.bug
+++ b/motoman/9bf25ea/9bf25ea.bug
@@ -29,8 +29,9 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/ros-industrial/motoman
-  hash: null
+  commits:
+    - repo: https://github.com/ros-industrial/motoman
+      hash: 9bf25eae1b495fd9ccacb904d93f82c959227582
   pull-request: 110
   license: ['BSD']
   fix-in: ['motoman_sia20d_support/urdf/sia20d_macro.xacro', 'motoman_sia10f_support/urdf/sia10f_macro.xacro']

--- a/motoman/9df36cb/9df36cb.bug
+++ b/motoman/9df36cb/9df36cb.bug
@@ -39,8 +39,9 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/ros-industrial/motoman
-  hash: null
+  commits:
+    - repo: https://github.com/ros-industrial/motoman
+      hash: 9df36cbd55b0efd7687bfe6a8d4a850e422ed751
   pull-request: 35
   license: ['BSD']
   fix-in: ['motoman_sia20d_moveit_config/package.xml']

--- a/motoman/acd5eab/acd5eab.bug
+++ b/motoman/acd5eab/acd5eab.bug
@@ -29,8 +29,9 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/ros-industrial/motoman
-  hash: null
+  commits:
+    - repo: https://github.com/ros-industrial/motoman
+      hash: acd5eab0744abd58059f1303947c6f1204ce92fe
   pull-request: 148
   license: ['BSD']
   fix-in:

--- a/motoman/b1b6fcb/b1b6fcb.bug
+++ b/motoman/b1b6fcb/b1b6fcb.bug
@@ -30,8 +30,12 @@ bug:
   trace: null
 fix:
   # TODO this one needs closer inspection by Gijs
+  # NOTE it looks like the id for the bug lines up with this repo/commit: https://github.com/traclabs/motoman/commit/b1b6fcb
+  #      but it seems that this is the commit we should be using: https://github.com/ros-industrial/motoman/commit/3f260cb3840095089fb4b743efd3d41695c75b26
   repo: https://github.com/ros-industrial/motoman
   hash: null
+  # TODO should we also list 155?
+  # https://github.com/ros-industrial/motoman/pull/155
   pull-request: 153
   license: ['BSD']
   fix-in:

--- a/motoman/b1b6fcb/b1b6fcb.bug
+++ b/motoman/b1b6fcb/b1b6fcb.bug
@@ -29,6 +29,7 @@ bug:
   reproducibility: always
   trace: null
 fix:
+  # TODO this one needs closer inspection by Gijs
   repo: https://github.com/ros-industrial/motoman
   hash: null
   pull-request: 153

--- a/motoman/b1b6fcb/b1b6fcb.bug
+++ b/motoman/b1b6fcb/b1b6fcb.bug
@@ -29,14 +29,9 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  # TODO this one needs closer inspection by Gijs
-  # NOTE it looks like the id for the bug lines up with this repo/commit: https://github.com/traclabs/motoman/commit/b1b6fcb
-  #      but it seems that this is the commit we should be using: https://github.com/ros-industrial/motoman/commit/3f260cb3840095089fb4b743efd3d41695c75b26
   repo: https://github.com/ros-industrial/motoman
-  hash: null
-  # TODO should we also list 155?
-  # https://github.com/ros-industrial/motoman/pull/155
-  pull-request: 153
+  hash: 3f260cb3840095089fb4b743efd3d41695c75b26
+  pull-request: https://github.com/ros-industrial/motoman/pull/155
   license: ['BSD']
   fix-in:
     - motoman_driver/include/motoman_driver/industrial_robot_client/joint_trajectory_action.h

--- a/motoman/ddc6f36/ddc6f36.bug
+++ b/motoman/ddc6f36/ddc6f36.bug
@@ -36,8 +36,9 @@ bug:
       report, since the package had not been released yet at the time.
       Testing is straightforward, as this is a build bug.
 fix:
-  repo: https://github.com/ros-industrial/motoman/
-  hash: null
+  commits:
+    - repo: https://github.com/ros-industrial/motoman
+      hash: ddc6f363dde1f1bc28d76908a6f950a333d659b0
   pull-request: 25
   license: ['BSD']
   fix-in: ['motoman_driver/CMakeLists.txt']

--- a/motoman/eadbcb8/eadbcb8.bug
+++ b/motoman/eadbcb8/eadbcb8.bug
@@ -30,8 +30,9 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/ros-industrial/motoman
-  hash: null
+  commits:
+    - repo: https://github.com/ros-industrial/motoman
+      hash: eadbcb8077cd5c6138cdd133ee61888cac377c91
   pull-request: 77
   license: ['BSD']
   fix-in:

--- a/motoman/eb99671/eb99671.bug
+++ b/motoman/eb99671/eb99671.bug
@@ -28,8 +28,9 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/ros-industrial/motoman/
-  hash: null
+  commits:
+    - repo: https://github.com/ros-industrial/motoman
+      hash: eb99671e195385b0ddc41e0a95c7c4592f5ee9ba
   pull-request: 3
   license: ['BSD']
   fix-in:

--- a/other/22e4e4f/22e4e4f.bug
+++ b/other/22e4e4f/22e4e4f.bug
@@ -34,11 +34,12 @@ bug:
   reproducibility: always
   trace: NA
 fix:
-  repo: https://git.code.tecnalia.com/robdream/kintinuous/commit/22e4e4f44ed3ead6f9d2d863fcd9d6d677e771f3
-  hash: 22e4e4f44ed3ead6f9d2d863fcd9d6d677e771f3
   pull-request: NA
   license: ['Tecnalia']
   fix-in: ['kintinuous_src/utils/Freenect2Reader.cpp']
   languages:
     - C++
   time: 2017-03-22 (11:46)
+  commits:
+    - repo: https://git.code.tecnalia.com/robdream/kintinuous/commit/22e4e4f44ed3ead6f9d2d863fcd9d6d677e771f3
+      hash: 22e4e4f44ed3ead6f9d2d863fcd9d6d677e771f3

--- a/other/473ab5e/473ab5e.bug
+++ b/other/473ab5e/473ab5e.bug
@@ -40,8 +40,6 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/shadow-robot/stiff_flop
-  hash: 473ab5eb82487fb024458c0d709463fb3e046e34
   pull-request: https://github.com/shadow-robot/stiff_flop/issues/276
   license: ['closed source']
   fix-in:
@@ -51,3 +49,6 @@ fix:
   languages:
     - Python
   time: 2015-12-07 (00:00)
+  commits:
+    - repo: https://github.com/shadow-robot/stiff_flop
+      hash: 473ab5eb82487fb024458c0d709463fb3e046e34

--- a/ros_comm/ca23e58/ca23e58.bug
+++ b/ros_comm/ca23e58/ca23e58.bug
@@ -53,8 +53,6 @@ bug:
   reproducibility: rare
   trace: null
 fix:
-  repo: https://github.com/ros/ros_comm
-  hash: ca23e58883ed2f1784840485ceba9af3cd2d5729
   pull-request: https://github.com/ros/ros_comm/pull/776
   license: ['BSD']
   fix-in:
@@ -64,3 +62,6 @@ fix:
     - C++
     - CMake
   time: 2016-03-17 (22:58)
+  commits:
+    - repo: https://github.com/ros/ros_comm
+      hash: ca23e58883ed2f1784840485ceba9af3cd2d5729

--- a/ros_comm/eab0d3c/eab0d3c.bug
+++ b/ros_comm/eab0d3c/eab0d3c.bug
@@ -28,11 +28,12 @@ bug:
   reproducibility: sometimes
   trace: null
 fix:
-  repo: https://github.com/ros/ros_comm
-  hash: eab0d3cd54fb419764e7f60e84b249d66ba6c3d1
   pull-request: null
   license: ['BSD']
   fix-in: ['clients/roscpp/src/libros/transport/transport_tcp.cpp']
   languages:
     - C++
   time: 2012-12-15 (01:06)
+  commits:
+    - repo: https://github.com/ros/ros_comm
+      hash: eab0d3cd54fb419764e7f60e84b249d66ba6c3d1

--- a/turtlebot/3390789/3390789.bug
+++ b/turtlebot/3390789/3390789.bug
@@ -33,11 +33,12 @@ bug:
     rosinstall file had to be patched manually. Cf. issue
     https://github.com/robust-rosin/robust/issues/63.
 fix:
-  repo: https://github.com/turtlebot/turtlebot
-  hash: 339078942cf67457bc472e07a3e75e9895ebf2f7
   pull-request: null
   license: ['BSD']
   fix-in: ['turtlebot_bringup/package.xml', 'turtlebot_capabilities/package.xml']
   languages:
     - Package XML
   time: 2015-01-09 (09:15)
+  commits:
+    - repo: https://github.com/turtlebot/turtlebot
+      hash: 339078942cf67457bc472e07a3e75e9895ebf2f7

--- a/turtlebot/3e32933/3e32933.bug
+++ b/turtlebot/3e32933/3e32933.bug
@@ -51,8 +51,6 @@ bug:
       As such, the bug_witness.test in this case contains a slice of the
       original launch file, and the buggy and fixed versions are different.
 fix:
-  repo: https://github.com/turtlebot/turtlebot
-  hash: 3e32933c829e308600707a9f971334d13d1cbe19
   pull-request: null
   license: ['BSD']
   fix-in:
@@ -60,3 +58,6 @@ fix:
   languages:
     - Launch XML
   time: 2014-04-02 (08:50)
+  commits:
+    - repo: https://github.com/turtlebot/turtlebot
+      hash: 3e32933c829e308600707a9f971334d13d1cbe19

--- a/turtlebot/3ea2c30/3ea2c30.bug
+++ b/turtlebot/3ea2c30/3ea2c30.bug
@@ -34,8 +34,11 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/turtlebot/turtlebot | https://github.com/turtlebot/turtlebot_apps
-  hash: 36ceb8dc37e0f930986cc86fe3ff2a9f1a930322 | 3ea2c306120774e8ed7e69e4e3fce3eca9f5426e
+  commits:
+    - repo: https://github.com/turtlebot/turtlebot
+      commit: 36ceb8dc37e0f930986cc86fe3ff2a9f1a930322
+    - repo: https://github.com/turtlebot/turtlebot_apps
+      hash: 3ea2c306120774e8ed7e69e4e3fce3eca9f5426e
   pull-request: null
   license: ['BSD']
   fix-in:

--- a/turtlebot/61a75df/61a75df.bug
+++ b/turtlebot/61a75df/61a75df.bug
@@ -40,14 +40,15 @@ bug:
     Testing the bug is straightforward. Since it is a Python import
     issue, it suffices for the unit test to import the affected files.
 fix:
-  repo: https://github.com/yujinrobot/kobuki_desktop
-  hash: 61a75df171e8ac8f34ed848456a7a267d4d9d3e3
   pull-request: https://github.com/yujinrobot/kobuki_desktop/pull/49
   license: ['BSD']
   fix-in: ['kobuki_dashboard/src/kobuki_dashboard/battery_widget.py', 'kobuki_dashboard/src/kobuki_dashboard/dashboard.py']
   languages:
     - Python
   time: 2017-02-22 (14:10)
+  commits:
+    - repo: https://github.com/yujinrobot/kobuki_desktop
+      hash: 61a75df171e8ac8f34ed848456a7a267d4d9d3e3
 time-machine:
   ros_distro: kinetic
   ros_pkgs:

--- a/turtlebot/891cb68/891cb68.bug
+++ b/turtlebot/891cb68/891cb68.bug
@@ -29,14 +29,15 @@ bug:
   reproduction: >
     geometry2
 fix:
-  repo: https://github.com/turtlebot/turtlebot
-  hash: 891cb680e98694e63a55394140bffdcde43f3f5e
   pull-request: null
   license: ['BSD']
   fix-in: ['turtlebot_bringup/package.xml']
   languages:
     - Package XML
   time: 2013-11-06 (08:29)
+  commits:
+    - repo: https://github.com/turtlebot/turtlebot
+      hash: 891cb680e98694e63a55394140bffdcde43f3f5e
 time-machine:
   ros_distro: hydro
   ros_pkgs:

--- a/turtlebot/928306b/928306b.bug
+++ b/turtlebot/928306b/928306b.bug
@@ -31,8 +31,11 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/turtlebot/turtlebot
-  hash: 0c0f53217bbd838d89f6be5584ae1b9f45106875 | 928306ba94acbfcc4e0ee61c7c8e432561b0824f
+  commits:
+    - repo: https://github.com/turtlebot/turtlebot
+      hash: 0c0f53217bbd838d89f6be5584ae1b9f45106875
+    - repo: https://github.com/turtlebot/turtlebot
+      hash: 928306ba94acbfcc4e0ee61c7c8e432561b0824f
   pull-request: https://github.com/turtlebot/turtlebot/pull/104
   license: ['BSD']
   fix-in:

--- a/turtlebot/9299530/9299530.bug
+++ b/turtlebot/9299530/9299530.bug
@@ -26,8 +26,11 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/turtlebot/turtlebot | https://github.com/turtlebot/turtlebot_create
-  hash: 8cf9d9710e9f2bfb1a7256e2ef292dd70138339c | 9299530eb77b9e8a2a18160fb6ece325d38abfbc
+  commits:
+    - repo: https://github.com/turtlebot/turtlebot
+      commit: 8cf9d9710e9f2bfb1a7256e2ef292dd70138339c
+    - repo: https://github.com/turtlebot/turtlebot_create
+      commit: 9299530eb77b9e8a2a18160fb6ece325d38abfbc
   pull-request: https://github.com/turtlebot/turtlebot/pull/66 | https://github.com/turtlebot/turtlebot_create/pull/7
   license: ['BSD']
   fix-in:

--- a/turtlebot/9ffffca/9ffffca.bug
+++ b/turtlebot/9ffffca/9ffffca.bug
@@ -33,11 +33,12 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/turtlebot/turtlebot
-  hash: 9ffffcaeca7dd5a1fbb327c7289b8a11f84da39f
   pull-request: https://github.com/turtlebot/turtlebot/pull/235
   license: ['BSD']
   fix-in: ['turtlebot_teleop/launch/includes/velocity_smoother.launch.xml']
   languages:
     - Launch XML
   time: 2016-10-26 (13:56)
+  commits:
+    - repo: https://github.com/turtlebot/turtlebot
+      hash: 9ffffcaeca7dd5a1fbb327c7289b8a11f84da39f

--- a/turtlebot/a482f82/a482f82.bug
+++ b/turtlebot/a482f82/a482f82.bug
@@ -27,8 +27,6 @@ bug:
   reproducibility: sometimes
   trace: null
 fix:
-  repo: https://github.com/ros-drivers/openni_launch
-  hash: a482f8268042aa8fae0e73970ed2af5dfd01e5df
   pull-request: https://github.com/ros-drivers/openni_launch/pull/3
   license: ['BSD']
   fix-in:
@@ -42,3 +40,6 @@ fix:
   languages:
     - Launch XML
   time: 2013-07-27 (02:39)
+  commits:
+    - repo: https://github.com/ros-drivers/openni_launch
+      hash: a482f8268042aa8fae0e73970ed2af5dfd01e5df

--- a/turtlebot/a4f35ee/a4f35ee.bug
+++ b/turtlebot/a4f35ee/a4f35ee.bug
@@ -43,10 +43,17 @@ bug:
         raise KeyError(os_key)
     KeyError: 'linuxmint'
 fix:
-  repo: https://github.com/robotics-in-concert/rocon_app_platform | https://github.com/ros-infrastructure/rospkg
-  hash: d379385c4de4323318dbb1dd901ab43a24189c19 | 862254530e105aa6a3a0919dc3c9c06c1b4be8cd
-    | 7a2a9038bdc4f643047360901b0f4f26b0d0ec79 | fceff44c1a5bd99c37f8643fa58a225c5999ec16
-    | a4f35ee51f0eb8f671173c65095b1a9c1963c5c3
+  commits:
+    - repo: https://github.com/robotics-in-concert/rocon_app_platform
+      hash: d379385c4de4323318dbb1dd901ab43a24189c19
+    - repo: https://github.com/ros-infrastructure/rospkg
+      hash: 862254530e105aa6a3a0919dc3c9c06c1b4be8cd
+    - repo: https://github.com/ros-infrastructure/rosdep
+      hash: 7a2a9038bdc4f643047360901b0f4f26b0d0ec79
+    - repo: https://github.com/ros-infrastructure/rosdep
+      hash: fceff44c1a5bd99c37f8643fa58a225c5999ec16
+    - repo: https://github.com/ros-infrastructure/rosdep
+      hash: a4f35ee51f0eb8f671173c65095b1a9c1963c5c3
   pull-request: https://github.com/robotics-in-concert/rocon_app_platform/pull/270
     | https://github.com/ros-infrastructure/rospkg/pull/78
   license: ['BSD']

--- a/turtlebot/f01d952/f01d952.bug
+++ b/turtlebot/f01d952/f01d952.bug
@@ -41,11 +41,12 @@ bug:
     rosinstall file had to be patched manually. Cf. issue
     https://github.com/robust-rosin/robust/issues/63.
 fix:
-  repo: https://github.com/ros-perception/image_pipeline
-  hash: f01d9525901b75858047e6fa81e4efc92c7dfedc
   pull-request: https://github.com/ros-perception/image_pipeline/pull/79
   license: ['BSD']
   fix-in: ['depth_image_proc/package.xml']
   languages:
     - Package XML
   time: 2014-06-13 (01:12)
+  commits:
+    - repo: https://github.com/ros-perception/image_pipeline
+      hash: f01d9525901b75858047e6fa81e4efc92c7dfedc

--- a/universal_robot/040fd11/040fd11.bug
+++ b/universal_robot/040fd11/040fd11.bug
@@ -43,11 +43,12 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/ros-industrial/universal_robot
-  hash: 040fd110f9281875d87b8e6aaba0c1c8f2d7d6fd
   pull-request: https://github.com/ros-industrial/universal_robot/pull/114
   license: ['BSD']
   fix-in: ['ur_kinematics/CMakeLists.txt']
   languages:
     - CMake
   time: 2014-10-10 (11:29)
+  commits:
+    - repo: https://github.com/ros-industrial/universal_robot
+      hash: 040fd110f9281875d87b8e6aaba0c1c8f2d7d6fd

--- a/universal_robot/082dcf1/082dcf1.bug
+++ b/universal_robot/082dcf1/082dcf1.bug
@@ -57,11 +57,12 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/ros-industrial/universal_robot
-  hash: 082dcf1551d84a9a874443adc39627f67272ac4c
   pull-request: https://github.com/ros-industrial/universal_robot/pull/100 | https://github.com/ros-industrial/universal_robot/pull/130
   license: ['BSD']
   fix-in: ['package.xml']
   languages:
     - Package XML
   time: 2014-09-04 (17:57)
+  commits:
+    - repo: https://github.com/ros-industrial/universal_robot
+      hash: 082dcf1551d84a9a874443adc39627f67272ac4c

--- a/universal_robot/0c34123/0c34123.bug
+++ b/universal_robot/0c34123/0c34123.bug
@@ -50,11 +50,12 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/ros-industrial/universal_robot
-  hash: 0c34123c779d4076a75acf892571f8ec4aa018cc
   pull-request: https://github.com/ros-industrial/universal_robot/pull/255
   license: ['BSD']
   fix-in: ['ur_gazebo/package.xml']
   languages:
     - Package XML
   time: 2016-08-22 (18:38)
+  commits:
+    - repo: https://github.com/ros-industrial/universal_robot
+      hash: 0c34123c779d4076a75acf892571f8ec4aa018cc

--- a/universal_robot/18ffa89/18ffa89.bug
+++ b/universal_robot/18ffa89/18ffa89.bug
@@ -50,11 +50,12 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/ros-industrial/universal_robot
-  hash: 18ffa89f797266ea519c2047dcb9416f0f79796b
   pull-request: https://github.com/ros-industrial/universal_robot/pull/7
   license: ['BSD']
   fix-in: ['ur_description/urdf/ur10.gazebo.xacro']
   languages:
     - Xacro
   time: 2013-06-06 (19:43)
+  commits:
+    - repo: https://github.com/ros-industrial/universal_robot
+      hash: 18ffa89f797266ea519c2047dcb9416f0f79796b

--- a/universal_robot/1e0904c/1e0904c.bug
+++ b/universal_robot/1e0904c/1e0904c.bug
@@ -47,11 +47,12 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/ros-industrial/universal_robot/
-  hash: 1e0904c38934fe09c9647825caf3b58dda2636f9
   pull-request: https://github.com/ros-industrial/universal_robot/pull/165
   license: ['BSD']
   fix-in: ['ur_driver/prog']
   languages:
     - URScript
   time: 2015-02-20 (11:24)
+  commits:
+    - repo: https://github.com/ros-industrial/universal_robot/
+      hash: 1e0904c38934fe09c9647825caf3b58dda2636f9

--- a/universal_robot/21b86f6/21b86f6.bug
+++ b/universal_robot/21b86f6/21b86f6.bug
@@ -50,11 +50,12 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/ros-industrial/universal_robot
-  hash: 21b86f63408a99aff35cd82ca6ac180a99566ee5
   pull-request: https://github.com/ros-industrial/universal_robot/pull/82
   license: ['BSD']
   fix-in: ['ur_description/urdf/ur10.urdf.xacro']
   languages:
     - Xacro
   time: 2014-08-06 (13:00)
+  commits:
+    - repo: https://github.com/ros-industrial/universal_robot
+      hash: 21b86f63408a99aff35cd82ca6ac180a99566ee5

--- a/universal_robot/359a2e9/359a2e9.bug
+++ b/universal_robot/359a2e9/359a2e9.bug
@@ -42,11 +42,12 @@ bug:
   reproducibility: sometimes
   trace: null
 fix:
-  repo: https://github.com/ros-industrial/universal_robot/
-  hash: 359a2e9d0c21b37c4fc077e08dbb56de771734cb
   pull-request: https://github.com/ros-industrial/universal_robot/pull/115 | https://github.com/ros-industrial/universal_robot/pull/117
   license: ['BSD']
   fix-in: ['ur_driver/prog']
   languages:
     - URScript
   time: 2014-10-10 (11:52)
+  commits:
+    - repo: https://github.com/ros-industrial/universal_robot/
+      hash: 359a2e9d0c21b37c4fc077e08dbb56de771734cb

--- a/universal_robot/39eb24f/39eb24f.bug
+++ b/universal_robot/39eb24f/39eb24f.bug
@@ -42,11 +42,12 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/ros-industrial/universal_robot/
-  hash: 39eb24f3a8ff0e358c210e87f1f3798755444f44
   pull-request: https://github.com/ros-industrial/universal_robot/pull/218 | https://github.com/ros-industrial/universal_robot/pull/222
   license: ['BSD']
   fix-in: ['ur_kinematics/include/ur_kinematics/ur_kin.h', 'ur_kinematics/src/ur_kin.cpp']
   languages:
     - C++
   time: 2015-09-21 (12:45)
+  commits:
+    - repo: https://github.com/ros-industrial/universal_robot/
+      hash: 39eb24f3a8ff0e358c210e87f1f3798755444f44

--- a/universal_robot/3a48064/3a48064.bug
+++ b/universal_robot/3a48064/3a48064.bug
@@ -47,11 +47,12 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/ros-industrial/universal_robot
-  hash: 3a4806400af6a6bd9c44bcdb2ee528bf81e45573
   pull-request: https://github.com/ros-industrial/universal_robot/pull/289
   license: ['BSD']
   fix-in: ['ur_gazebo/package.xml']
   languages:
     - Package XML
   time: 2017-02-24 (13:00)
+  commits:
+    - repo: https://github.com/ros-industrial/universal_robot
+      hash: 3a4806400af6a6bd9c44bcdb2ee528bf81e45573

--- a/universal_robot/56cf07f/56cf07f.bug
+++ b/universal_robot/56cf07f/56cf07f.bug
@@ -57,8 +57,6 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/ros-industrial/universal_robot
-  hash: 56cf07f62fcdd3927ebff216da281d3b975adefc
   pull-request:
     - https://github.com/ros-industrial/universal_robot/pull/14
     - https://github.com/ros-industrial/universal_robot/pull/19
@@ -72,3 +70,6 @@ fix:
   languages:
     - CMake
   time: 2013-10-01 (21:20)
+  commits:
+    - repo: https://github.com/ros-industrial/universal_robot
+      hash: 56cf07f62fcdd3927ebff216da281d3b975adefc

--- a/universal_robot/58790ba/58790ba.bug
+++ b/universal_robot/58790ba/58790ba.bug
@@ -47,8 +47,6 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/ros-industrial/universal_robot
-  hash: 58790baa5bf6601f73bc821b5ebd9a24c0a613b4
   pull-request: https://github.com/ros-industrial/universal_robot/pull/30
   license: ['BSD']
   fix-in:
@@ -56,3 +54,6 @@ fix:
   languages:
     - Package XML
   time: 2013-11-26 (00:00)
+  commits:
+    - repo: https://github.com/ros-industrial/universal_robot
+      hash: 58790baa5bf6601f73bc821b5ebd9a24c0a613b4

--- a/universal_robot/778c1ac/778c1ac.bug
+++ b/universal_robot/778c1ac/778c1ac.bug
@@ -42,8 +42,6 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/ros-industrial/universal_robot
-  hash: 778c1acda6dc3e194b50328259936c3f058bcb7
   pull-request: https://github.com/ros-industrial/universal_robot/pull/285
   license: ['BSD']
   fix-in:
@@ -53,3 +51,6 @@ fix:
   languages:
     - Launch XML
   time: 2017-01-05 (05:58)
+  commits:
+    - repo: https://github.com/ros-industrial/universal_robot
+      hash: 778c1acda6dc3e194b50328259936c3f058bcb7

--- a/universal_robot/89145c4/89145c4.bug
+++ b/universal_robot/89145c4/89145c4.bug
@@ -44,11 +44,12 @@ bug:
   reproducibility: sometimes
   trace: null
 fix:
-  repo: https://github.com/ros-industrial/universal_robot
-  hash: 89145c420d9b6bbfb4d385d43205708d45cc9449
   pull-request: https://github.com/ros-industrial/universal_robot/pull/268 | https://github.com/ros-industrial/universal_robot/pull/302
   license: ['BSD']
   fix-in: ['ur_description/urdf/ur10.urdf.xacro', 'ur_description/urdf/ur5.urdf.xacro']
   languages:
     - Xacro
   time: unfixed
+  commits:
+    - repo: https://github.com/ros-industrial/universal_robot
+      hash: 89145c420d9b6bbfb4d385d43205708d45cc9449

--- a/universal_robot/a58f4b5/a58f4b5.bug
+++ b/universal_robot/a58f4b5/a58f4b5.bug
@@ -48,11 +48,12 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/ros-industrial/universal_robot
-  hash: a58f4b506ae8bd774829fb6b7ceede1c1b812d15
   pull-request: https://github.com/ros-industrial/universal_robot/pull/261
   license: ['BSD']
   fix-in: ['ur10_moveit_config/package.xml', 'ur3_moveit_config/package.xml', 'ur5_moveit_config/package.xml']
   languages:
     - Package XML
   time: 2016-09-02 (01:02)
+  commits:
+    - repo: https://github.com/ros-industrial/universal_robot
+      hash: a58f4b506ae8bd774829fb6b7ceede1c1b812d15

--- a/universal_robot/b3c2c21/b3c2c21.bug
+++ b/universal_robot/b3c2c21/b3c2c21.bug
@@ -42,11 +42,12 @@ bug:
   reproducibility: sometimes
   trace: null
 fix:
-  repo: https://github.com/ros-industrial/universal_robot
-  hash: b3c2c215b4fc46bb66ca61e6e693920540d0daef
   pull-request: https://github.com/ros-industrial/universal_robot/pull/157 | https://github.com/ros-industrial/universal_robot/pull/189
   license: ['BSD']
   fix-in: ['ur_driver/src/ur_driver/driver.py']
   languages:
     - Python
   time: 2015-03-12 (14:44)
+  commits:
+    - repo: https://github.com/ros-industrial/universal_robot
+      hash: b3c2c215b4fc46bb66ca61e6e693920540d0daef

--- a/universal_robot/bd1fce5/bd1fce5.bug
+++ b/universal_robot/bd1fce5/bd1fce5.bug
@@ -35,11 +35,12 @@ bug:
   reproducibility: sometimes
   trace: null
 fix:
-  repo: https://github.com/ros-industrial/universal_robot
-  hash: bd1fce5b225aecc4862e824b674eebb4c40be255
   pull-request: https://github.com/ros-industrial/universal_robot/pull/37
   license: ['BSD']
   fix-in: ['ur_driver/src/ur_driver/driver.py']
   languages:
     - Python
   time: 2014-02-08 (03:30)
+  commits:
+    - repo: https://github.com/ros-industrial/universal_robot
+      hash: bd1fce5b225aecc4862e824b674eebb4c40be255

--- a/universal_robot/c4e1187/c4e1187.bug
+++ b/universal_robot/c4e1187/c4e1187.bug
@@ -38,11 +38,12 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/ros-industrial/universal_robot/
-  hash: c4e118757123ef243d0f3c2e14a6c3d63549f20d
   pull-request: https://github.com/ros-industrial/universal_robot/pull/303
   license: ['BSD']
   fix-in: ['ur_kinematics/src/ur_moveit_plugin.cpp']
   languages:
     - C++
   time: unfixed
+  commits:
+    - repo: https://github.com/ros-industrial/universal_robot/
+      hash: c4e118757123ef243d0f3c2e14a6c3d63549f20d

--- a/universal_robot/c779432/c779432.bug
+++ b/universal_robot/c779432/c779432.bug
@@ -38,8 +38,6 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/ros-industrial/universal_robot/
-  hash: c7794329bf632592bf1d345d1290ff4b8d13580a
   pull-request: https://github.com/ros-industrial/universal_robot/pull/286
   license: ['BSD']
   fix-in:
@@ -48,3 +46,6 @@ fix:
   languages:
     - CMake
   time: 2017-01-06 (12:29)
+  commits:
+    - repo: https://github.com/ros-industrial/universal_robot/
+      hash: c7794329bf632592bf1d345d1290ff4b8d13580a

--- a/universal_robot/cd273dd/cd273dd.bug
+++ b/universal_robot/cd273dd/cd273dd.bug
@@ -35,11 +35,12 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/ros-industrial/universal_robot
-  hash: cd273dd7fdc767c6cc8f4e7f60a165577af0e6c0
   pull-request: https://github.com/ros-industrial/universal_robot/pull/42
   license: ['BSD']
   fix-in: ['ur5_moveit_config/package.xml']
   languages:
     - Package XML
   time: 2014-03-21 (02:53)
+  commits:
+    - repo: https://github.com/ros-industrial/universal_robot
+      hash: cd273dd7fdc767c6cc8f4e7f60a165577af0e6c0

--- a/universal_robot/cda133d/cda133d.bug
+++ b/universal_robot/cda133d/cda133d.bug
@@ -40,11 +40,12 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/ros-industrial/universal_robot
-  hash: b2abe31a90a92b5ebd26cd2e39c260d6151d0daa
   pull-request: https://github.com/ros-industrial/universal_robot/pull/110
   license: ['BSD']
   fix-in: ['ur_driver/prog']
   languages:
     - URScript
   time: 2014-10-10 (11:26)
+  commits:
+    - repo: https://github.com/ros-industrial/universal_robot
+      hash: b2abe31a90a92b5ebd26cd2e39c260d6151d0daa

--- a/universal_robot/dda2f60/dda2f60.bug
+++ b/universal_robot/dda2f60/dda2f60.bug
@@ -30,11 +30,12 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/ros-industrial/universal_robot
-  hash: dda2f607be5f6650f7ce32b64d2cc413a8938c15
   pull-request: https://github.com/ros-industrial/universal_robot/pull/53
   license: ['BSD']
   fix-in: ['ros_industrial/universal_robot/package.xml']
   languages:
     - Package XML
   time: 2014-03-31 (15:52)
+  commits:
+    - repo: https://github.com/ros-industrial/universal_robot
+      hash: dda2f607be5f6650f7ce32b64d2cc413a8938c15

--- a/universal_robot/e122ccc/e122ccc.bug
+++ b/universal_robot/e122ccc/e122ccc.bug
@@ -42,11 +42,12 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/ros-industrial/universal_robot
-  hash: e122ccc26d8b96f1534a51fc3f0f34638f63c657
   pull-request: https://github.com/ros-industrial/universal_robot/pull/236
   license: ['BSD']
   fix-in: ['ur10_moveit_config/package.xml', 'ur3_moveit_config/package.xml', 'ur5_moveit_config/package.xml']
   languages:
     - Package XML
   time: 2016-04-01 (15:59)
+  commits:
+    - repo: https://github.com/ros-industrial/universal_robot
+      hash: e122ccc26d8b96f1534a51fc3f0f34638f63c657

--- a/universal_robot/f8d175b/f8d175b.bug
+++ b/universal_robot/f8d175b/f8d175b.bug
@@ -42,8 +42,6 @@ bug:
     fixed: 8f7f2418edc1d507853c1c766b6a79123393007b
     rosdistro: ros/rosdistro@75ab3e205a0d04fc81763657736742e315733956
 fix:
-  repo: https://github.com/ros-industrial/universal_robot/
-  hash: f8d175b09ea955ebe83aecbe19105c28f0225524
   pull-request: https://github.com/ros-industrial/universal_robot/pull/275
   license: ['BSD']
   fix-in: ['ur_kinematics/CMakeLists.txt', 'ur_kinematics/package.xml']
@@ -51,3 +49,6 @@ fix:
     - CMake
     - Package XML
   time: 2016-12-29 (20:34)
+  commits:
+    - repo: https://github.com/ros-industrial/universal_robot/
+      hash: f8d175b09ea955ebe83aecbe19105c28f0225524

--- a/universal_robot/fa64ec6/fa64ec6.bug
+++ b/universal_robot/fa64ec6/fa64ec6.bug
@@ -53,8 +53,6 @@ bug:
   reproducibility: always
   trace: null
 fix:
-  repo: https://github.com/ros-industrial/universal_robot
-  hash: fa64ec6585745c60fa02cf3be13b6d78bf449d8d
   pull-request: https://github.com/ros-industrial/universal_robot/pull/251
   license: ['BSD']
   fix-in:
@@ -64,3 +62,6 @@ fix:
   languages:
     - Xacro
   time: 2016-12-29 (20:59)
+  commits:
+    - repo: https://github.com/ros-industrial/universal_robot
+      hash: fa64ec6585745c60fa02cf3be13b6d78bf449d8d

--- a/universal_robot/fc95a19/fc95a19.bug
+++ b/universal_robot/fc95a19/fc95a19.bug
@@ -51,11 +51,12 @@ bug:
   reproducibility: sometimes
   trace: null
 fix:
-  repo: https://github.com/ros-industrial/universal_robot/
-  hash: fc95a19ac913e31c09ab52666405be0f5aacc24e
   pull-request: https://github.com/ros-industrial/universal_robot/pull/136
   license: ['BSD']
   fix-in: ['ur_driver/src/ur_driver/driver.py']
   languages:
     - Python
   time: 2014-11-03 (16:30)
+  commits:
+    - repo: https://github.com/ros-industrial/universal_robot/
+      hash: fc95a19ac913e31c09ab52666405be0f5aacc24e


### PR DESCRIPTION
I modified the `scripts/reformat` script introduced in #381 to automate the bulk of this refactoring, as shown below:

```python
def refactor_fix_commits(description: t.Dict[str, t.Any]) -> None:
    fix_description = description['fix']

    # we've already refactored this file
    if 'commits' in fix_description:
        return

    try:
        fix_repo = fix_description['repo']
        fix_hash = fix_description['hash']
    except KeyError as err:
        raise ValueError(f"fix section missing field: {err}")

    if fix_hash is None:
        raise ValueError("fix.hash is missing")
    if fix_repo is None:
        raise ValueError("fix.repo is missing")
    if '|' in fix_hash:
        raise ValueError("fix.hash appears to contain more than one hash.")
    if '|' in fix_repo:
        raise ValueError("fix.repo appears to contain more than one repo.")

    commit = {'repo': fix_repo, 'hash': fix_hash}
    fix_description['commits'] = [commit]
    del fix_description['repo']
    del fix_description['hash']


def reformat_file(filename: str) -> None:
    with open(filename, 'r') as f:
        description = yaml.load(f)

    try:
        refactor_fix_commits(description)
    except ValueError as err:
        print(f"ERROR [{filename}]: {err}")

    with open(filename, 'w') as f:
        yaml.dump(description, f)
```
